### PR TITLE
DM-12851: Determine whether dataset framework can be made generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 Template repo for developing datasets for use with ap_verify.
 
-This repo is designed to be used as a template for developing new data sets for integration into `ap_verify`.
+This repo is designed to be used as a template for developing new datasets for integration into `ap_verify`.
 
-It is currently set up for using `obs_test`.
+Datasets must link to the corresponding instrument's obs package; this template is currently set up for using [`obs_test`](https://github.com/lsst/obs_test/) as a placeholder.
 
 Relevant Files and Directories
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This repo is designed to be used as a template for developing new data sets for 
 It is currently set up for using `obs_test`.
 
 Relevant Files and Directories
------
+------------------------------
 path                  | description
 :---------------------|:-----------------------------
-`raw`                 | To be populated with raw data. Currently contains a single small fits file (taken from `obs_test`) to test `git-lfs` functionality.
-`calib`               | To be populated with master calibs. Currently empty.
-`templates`           | To be populated with calibrated images intended to be used as templates. Currently empty.
+`raw`                 | To be populated with raw data. Data files do not need to follow a specific subdirectory structure. Currently contains a single small fits file (taken from `obs_test`) to test `git-lfs` functionality.
+`calib`               | To be populated with master calibs. Calibration files do not need to follow a specific subdirectory structure. Currently empty.
+`templates`           | To be populated with `TemplateCoadd` images produced by a compatible version of the LSST pipelines. Must be organized as a filesystem-based Butler repo. Currently empty.
 `repo`                | Butler repo into which raw data can be ingested.  This should be copied to an appropriate location before ingestion.  Note that the `_mapper` file will require updating for other instruments.
 `refcats`             | To be populated with tarball(s) of HTM shards from relevant reference catalogs. Currently contains a small (useless) example tarball.
 `dataIds.list`        | List of dataIds in this repo. For use in running Tasks. Currently set to run all Ids.


### PR DESCRIPTION
This PR updates the instructions to clarify what is and is not required (very little) when filling in the `raw` and `calib` directories. The out-of-date description of `templates` is also fixed.