### PR TITLE
DM-13530: Generalize ingestion to non-HiTS data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ path                  | description
 :---------------------|:-----------------------------
 `raw`                 | To be populated with raw data. Data files do not need to follow a specific subdirectory structure. Currently contains a single small fits file (taken from `obs_test`) to test `git-lfs` functionality.
 `calib`               | To be populated with master calibs. Calibration files do not need to follow a specific subdirectory structure. Currently empty.
+`config`              | To be populated with dataset-specific configs. Currently contains an example file corresponding to the contents of `raw` and `refcats`.
 `templates`           | To be populated with `TemplateCoadd` images produced by a compatible version of the LSST pipelines. Must be organized as a filesystem-based Butler repo. Currently empty.
 `repo`                | Butler repo into which raw data can be ingested.  This should be copied to an appropriate location before ingestion.  Note that the `_mapper` file will require updating for other instruments.
 `refcats`             | To be populated with tarball(s) of HTM shards from relevant reference catalogs. Currently contains a small (useless) example tarball.

--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -1,0 +1,3 @@
+config.dataFiles = ['*.fits.gz']
+
+config.refcats = {'gaia': 'gaia_example.tar.gz'}


### PR DESCRIPTION
This PR adds a config directory to the dataset format. This directory lets `ap_verify` and other dataset clients read dataset-specific information automatically, without needing user input beyond the dataset name.