### PR TITLE
DM-14557: Add package docs to datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+doc/_build
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Relevant Files and Directories
 ------------------------------
 path                  | description
 :---------------------|:-----------------------------
+`doc`                 | Contains Sphinx package documentation for the dataset. This documentation may be linked to from other packages, such as `ap_verify`.
 `raw`                 | To be populated with raw data. Data files do not need to follow a specific subdirectory structure. Currently contains a single small fits file (taken from `obs_test`) to test `git-lfs` functionality.
 `calib`               | To be populated with master calibs. Calibration files do not need to follow a specific subdirectory structure. Currently empty.
 `config`              | To be populated with dataset-specific configs. Currently contains an example file corresponding to the contents of `raw` and `refcats`.

--- a/doc/ap_verify_dataset_template/index.rst
+++ b/doc/ap_verify_dataset_template/index.rst
@@ -1,0 +1,36 @@
+.. _ap_verify_dataset_template-package:
+
+##########################
+ap_verify_dataset_template
+##########################
+
+The ``ap_verify_dataset_template`` package is used to create :ref:`datasets<ap-verify-datasets>` for `lsst.ap.verify`.
+It is not itself a valid dataset.
+
+Project info
+============
+
+Repository
+   https://github.com/lsst-dm/ap_verify_dataset_template
+
+.. Datasets do not have their own (or a collective) Jira components; by convention we include them in ap_verify
+
+Jira component
+   `ap_verify <https://jira.lsstcorp.org/issues/?jql=project %3D DM %20AND%20 component %3D ap_verify %20AND%20 text ~ "dataset template">`_
+
+Dataset Contents
+================
+
+This package provides a number of demonstration files copied from `obs_test <https://github.com/lsst/obs_test/>`_.
+See that package for detailed file and provenance information.
+
+This package contains only raw files, with no calibration information or difference imaging templates.
+It contains a small Gaia DR1 reference catalog for illustrating the catalog format.
+The catalog is not guaranteed to overlap with the footprint of the raw data.
+
+Intended Use
+============
+
+This package provides an example for how a dataset package can be put together.
+It is not guaranteed to be ingestible using ``ap_verify``, nor are the individual files guaranteed to be usable with each other.
+The package provides some instructions on how to create a new dataset; more information can be found in :ref:`ap-verify-datasets-creation`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,12 @@
+"""Sphinx configuration file for an LSST stack package.
+
+This configuration only affects single-package Sphinx documenation builds.
+"""
+
+from documenteer.sphinxconfig.stackconf import build_package_configs
+
+
+_g = globals()
+_g.update(build_package_configs(
+    project_name='ap_verify_dataset_template',))
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,13 @@
+################################################
+ap_verify_dataset_template documentation preview
+################################################
+
+.. This page is for local development only. It isn't published to pipelines.lsst.io.
+
+.. Link the index pages of package and module documentation directions (listed in manifest.yaml).
+
+.. toctree::
+   :maxdepth: 1
+
+   ap_verify_dataset_template/index
+

--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -1,0 +1,16 @@
+# Documentation manifest.
+
+# Name of this package
+# Also the name of the package documentation subdirectory.
+package: "ap_verify_dataset_template"
+
+# List of names of Python modules in this package.
+# For each module there is a corresponding module doc subdirectory.
+# modules:
+#   - "lsst.ap.verify.dataset_template"
+
+# Name of the static content directories (subdirectories of `_static`).
+# Static content directories are usually named after the package.
+# statics:
+#   - "_static/ap_verify_dataset_template"
+


### PR DESCRIPTION
This PR adds a Sphinx documentation template to the dataset format, so that documentation of the dataset framework (particularly in the `ap_verify` docs) can link to supported datasets.