### PR TITLE
DM-14593: Clarify use of repo subdirectory in ap_verify_hits2015 dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ path                  | description
 `calib`               | To be populated with master calibs. Calibration files do not need to follow a specific subdirectory structure. Currently empty.
 `config`              | To be populated with dataset-specific configs. Currently contains an example file corresponding to the contents of `raw` and `refcats`.
 `templates`           | To be populated with `TemplateCoadd` images produced by a compatible version of the LSST pipelines. Must be organized as a filesystem-based Butler repo. Currently empty.
-`repo`                | Butler repo into which raw data can be ingested.  This should be copied to an appropriate location before ingestion.  Note that the `_mapper` file will require updating for other instruments.
+`repo`                | A template for a Butler raw data repository. This directory must never be written to; instead, it should be copied to a separate location, and data ingested into the copy (this is handled automatically by `ap_verify`, see below). Note that the `_mapper` file will require updating for other instruments.
 `refcats`             | To be populated with tarball(s) of HTM shards from relevant reference catalogs. Currently contains a small (useless) example tarball.
 `dataIds.list`        | List of dataIds in this repo. For use in running Tasks. Currently set to run all Ids.
 
@@ -28,3 +28,18 @@ To clone and use this repository, you'll need Git Large File Storage (LFS).
 
 Our [Developer Guide](http://developer.lsst.io/en/latest/tools/git_lfs.html) explains how to setup Git LFS for LSST development.
 
+Usage
+-----
+
+<!-- TODO: replace with just links to Sphinx labels `ap-verify-datasets-install` and `ap-verify-running` once those docs are published -->
+
+Datasets must be cloned (with Git LFS) and set up with [EUPS](https://developer.lsst.io/stack/eups-tutorial.html) before they can be processed with `ap_verify`.
+Then, run `ap_verify` to ingest and process the dataset through the AP pipeline:
+
+    ap_verify.py --dataset <DATASET> --id "<DATA ID FOR SINGLE IMAGE>" --output /my_output_dir/ --silent
+
+or, instead, run `ingest_dataset` to create standard Butler repositories for other purposes:
+
+    ingest_dataset.py --dataset <DATASET> --output /my_output_dir/
+
+See the [`ap_verify`](https://github.com/lsst-dm/ap_verify/) documentation for more details.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Template repo for developing datasets for use with ap_verify.
 
-This repo is designed to be used as a template for developing new datasets for integration into `ap_verify`.
+This repo is designed to be used as a template for developing new datasets for integration into [`ap_verify`](https://github.com/lsst-dm/ap_verify/).
 
 Datasets must link to the corresponding instrument's obs package; this template is currently set up for using [`obs_test`](https://github.com/lsst/obs_test/) as a placeholder.
 


### PR DESCRIPTION
This PR adds a skeleton usage guide to the template Readme. Installation instructions are meant to be fleshed out by real datasets.