### PR TITLE
DM-15872: Incorporate AP documentation into pipelines.lsst.io

### DIFF
--- a/doc/ap_verify_dataset_template/index.rst
+++ b/doc/ap_verify_dataset_template/index.rst
@@ -4,7 +4,7 @@
 ap_verify_dataset_template
 ##########################
 
-The ``ap_verify_dataset_template`` package is used to create :doc:`datasets</modules/lsst.ap.verify/datasets>` for `lsst.ap.verify`.
+The ``ap_verify_dataset_template`` package is used to create :doc:`datasets</modules/lsst.ap.verify/datasets>` for :doc:`/modules/lsst.ap.verify/index`.
 It is not itself a valid dataset.
 
 .. _ap_verify_dataset_template-using:

--- a/doc/ap_verify_dataset_template/index.rst
+++ b/doc/ap_verify_dataset_template/index.rst
@@ -4,7 +4,7 @@
 ap_verify_dataset_template
 ##########################
 
-The ``ap_verify_dataset_template`` package is used to create :ref:`datasets<ap-verify-datasets>` for `lsst.ap.verify`.
+The ``ap_verify_dataset_template`` package is used to create :doc:`datasets</modules/lsst.ap.verify/datasets>` for `lsst.ap.verify`.
 It is not itself a valid dataset.
 
 .. _ap_verify_dataset_template-using:
@@ -14,7 +14,7 @@ Using ap_verify_dataset_template
 
 This package provides an example for how a dataset package can be put together.
 It is not guaranteed to be ingestible using ``ap_verify``, nor are the individual files guaranteed to be usable with each other.
-The package provides some instructions on how to create a new dataset; more information can be found in :ref:`ap-verify-datasets-creation`.
+The package provides some instructions on how to create a new dataset; more information can be found in :doc:`/modules/lsst.ap.verify/datasets-creation`.
 
 .. _ap_verify_dataset_template-contents:
 

--- a/doc/ap_verify_dataset_template/index.rst
+++ b/doc/ap_verify_dataset_template/index.rst
@@ -7,18 +7,18 @@ ap_verify_dataset_template
 The ``ap_verify_dataset_template`` package is used to create :ref:`datasets<ap-verify-datasets>` for `lsst.ap.verify`.
 It is not itself a valid dataset.
 
-Project info
-============
+.. _ap_verify_dataset_template-using:
 
-Repository
-   https://github.com/lsst-dm/ap_verify_dataset_template
+Using ap_verify_dataset_template
+================================
 
-.. Datasets do not have their own (or a collective) Jira components; by convention we include them in ap_verify
+This package provides an example for how a dataset package can be put together.
+It is not guaranteed to be ingestible using ``ap_verify``, nor are the individual files guaranteed to be usable with each other.
+The package provides some instructions on how to create a new dataset; more information can be found in :ref:`ap-verify-datasets-creation`.
 
-Jira component
-   `ap_verify <https://jira.lsstcorp.org/issues/?jql=project %3D DM %20AND%20 component %3D ap_verify %20AND%20 text ~ "dataset template">`_
+.. _ap_verify_dataset_template-contents:
 
-Dataset Contents
+Dataset contents
 ================
 
 This package provides a number of demonstration files copied from `obs_test <https://github.com/lsst/obs_test/>`_.
@@ -28,9 +28,15 @@ This package contains only raw files, with no calibration information or differe
 It contains a small Gaia DR1 reference catalog for illustrating the catalog format.
 The catalog is not guaranteed to overlap with the footprint of the raw data.
 
-Intended Use
+.. _ap_verify_dataset_template-contributing:
+
+Contributing
 ============
 
-This package provides an example for how a dataset package can be put together.
-It is not guaranteed to be ingestible using ``ap_verify``, nor are the individual files guaranteed to be usable with each other.
-The package provides some instructions on how to create a new dataset; more information can be found in :ref:`ap-verify-datasets-creation`.
+``ap_verify_dataset_template`` is developed at https://github.com/lsst-dm/ap_verify_dataset_template.
+You can find Jira issues for this module under the `ap_verify <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_verify%20AND%20text~"dataset template">`_ component.
+
+.. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
+
+.. .. toctree::
+..    :maxdepth: 1

--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -4,13 +4,8 @@
 # Also the name of the package documentation subdirectory.
 package: "ap_verify_dataset_template"
 
-# List of names of Python modules in this package.
-# For each module there is a corresponding module doc subdirectory.
-# modules:
-#   - "lsst.ap.verify.dataset_template"
-
 # Name of the static content directories (subdirectories of `_static`).
 # Static content directories are usually named after the package.
+# Most packages do not need a static content directory (leave commented out).
 # statics:
 #   - "_static/ap_verify_dataset_template"
-


### PR DESCRIPTION
This PR updates the documentation to current data package conventions and fixes build errors detected when building with `pipelines_lsst_io`. Note that this documentation is not built by pipelines.lsst.io, as this package is a DM developer tool rather than part of the Stack.