### PR TITLE
DM-24260: Create Gen3 versions of ap_verify datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,24 @@ path                  | description
 `calib`               | To be populated with master calibs. Calibration files do not need to follow a specific subdirectory structure. Currently empty.
 `config`              | To be populated with dataset-specific configs. Currently contains an example file corresponding to the contents of `raw` and `refcats`.
 `templates`           | To be populated with `TemplateCoadd` images produced by a compatible version of the LSST pipelines. Must be organized as a filesystem-based Butler repo. Currently empty.
-`repo`                | A template for a Butler raw data repository. This directory must never be written to; instead, it should be copied to a separate location, and data ingested into the copy (this is handled automatically by `ap_verify`, see below). Note that the `_mapper` file will require updating for other instruments.
+`repo`                | A template for a Gen 2 Butler raw data repository. This directory must never be written to; instead, it should be copied to a separate location, and data ingested into the copy (this is handled automatically by `ap_verify`, see below). Note that the `_mapper` file will require updating for other instruments.
+`preloaded`           | To be populated with a Gen 3 Butler repository (see below). This repository must never be written to; instead, it should be copied to a separate location (this is handled automatically by `ap_verify`, see below). Currently empty.
 `refcats`             | To be populated with tarball(s) of HTM shards from relevant reference catalogs. Currently contains a small (useless) example tarball.
 `dataIds.list`        | List of dataIds in this repo. For use in running Tasks. Currently set to run all Ids.
 
+
+Gen 3 Collections
+-----------------
+
+The Gen 3 repository in `preloaded/` must contain the following collections.
+These may duplicate the directories above to support both Gen 2 and Gen 3 processing.
+
+collection            | description
+:---------------------|:-----------------------------
+`calib/<instrument>`  | Master calibration files for the data in the `raw` directory.
+`refcats`             | HTM shards from relevant reference catalogs.
+`skymaps`             | Skymaps for the template coadds.
+`templates/<type>`    | Coadd images produced by a compatible version of the LSST pipelines. For example, `deepCoadd` images go in a `templates/deep` collection.
 
 Git LFS
 -------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ path                  | description
 `config`              | To be populated with dataset-specific configs. Currently contains an example file corresponding to the contents of `raw` and `refcats`.
 `templates`           | To be populated with `TemplateCoadd` images produced by a compatible version of the LSST pipelines. Must be organized as a filesystem-based Butler repo. Currently empty.
 `repo`                | A template for a Gen 2 Butler raw data repository. This directory must never be written to; instead, it should be copied to a separate location, and data ingested into the copy (this is handled automatically by `ap_verify`, see below). Note that the `_mapper` file will require updating for other instruments.
-`preloaded`           | To be populated with a Gen 3 Butler repository (see below). This repository must never be written to; instead, it should be copied to a separate location (this is handled automatically by `ap_verify`, see below). Currently empty.
+`preloaded`           | To be populated with a Gen 3 Butler repository (see below). This repository must never be written to; instead, it should be copied to a separate location (this is handled automatically by `ap_verify`, see below). Currently empty, but can be populated from the other directories using `scripts/add_gen3_repo.py`.
 `refcats`             | To be populated with tarball(s) of HTM shards from relevant reference catalogs. Currently contains a small (useless) example tarball.
 `dataIds.list`        | List of dataIds in this repo. For use in running Tasks. Currently set to run all Ids.
 

--- a/config/convertRepo_calibs.py
+++ b/config/convertRepo_calibs.py
@@ -1,0 +1,3 @@
+# Config overrides for convert_gen2_repo_to_gen3.py
+
+config.datasetIgnorePatterns = ["raw", "*Coadd_skyMap", "ref_cat", "defects"]

--- a/config/convertRepo_copied.py
+++ b/config/convertRepo_copied.py
@@ -1,0 +1,12 @@
+
+# Config overrides for convert_gen2_repo_to_gen3.py
+
+config.datasetIncludePatterns = ["ref_cat", "defects"]
+
+config.refCats = ['gaia']
+for refcat in config.refCats:
+    config.runs[refcat] = "refcats"
+
+# Already stored in convertRepo_calibs.py
+config.doRegisterInstrument = False
+config.doWriteCuratedCalibrations = False

--- a/config/convertRepo_templates.py
+++ b/config/convertRepo_templates.py
@@ -1,0 +1,7 @@
+# Config overrides for convert_gen2_repo_to_gen3.py
+
+# Pass only templates and their supporting types
+config.datasetIncludePatterns = ["*Coadd*"]
+config.datasetIgnorePatterns = []
+for coaddType in ["deep", "goodSeeing", "dcr"]:
+    config.runs[f"{coaddType}Coadd"] = f"templates/{coaddType}"

--- a/scripts/add_gen3_repo.py
+++ b/scripts/add_gen3_repo.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+
+"""Convert a Gen 2 dataset to a Gen 3 dataset.
+
+By default, this creates a hybrid Gen 2/3 dataset with shared files. A flag
+lets a dataset be permanently migrated to Gen 3 instead.
+"""
+
+import argparse
+import os
+import shutil
+import tempfile
+
+import lsst.log
+import lsst.daf.butler as daf_butler
+from lsst.obs.base.script import convertGen2RepoToGen3
+import lsst.ap.verify as ap_verify
+
+
+class _Parser(argparse.ArgumentParser):
+    def __init__(self, **kwargs):
+        # super() causes problems with program name
+        argparse.ArgumentParser.__init__(
+            self,
+            description="Copy a dataset's Gen 2 files into the Gen 3 format, overwriting a previous copy "
+                        "if necessary. This creates a hybrid Gen 2/3 dataset unless the --drop-gen2 flag "
+                        "is provided. DO NOT delete the Gen 2 files unless this flag has been used, as the "
+                        "Gen 3 part of a hybrid dataset depends on them.\n\n"
+                        "Assumes that the dataset's config directory has three configs for "
+                        "obs.base.gen2to3.ConvertRepoTask: convertRepo_calibs.py, convertRepo_copied.py and "
+                        "convertRepo_templates.py. See ap_verify_dataset_template/config for examples.",
+            **kwargs)
+        self.add_argument("--dataset", required=True,
+                          help="The name of the dataset as recognized by ap_verify.py.")
+        self.add_argument("--drop-gen2", action="store_true",
+                          help="Create a standalone Gen 3 repo instead of sharing files with Gen 2. "
+                               "Intended for use only once ap_verify no longer supports Gen 2.")
+
+
+def main():
+    args = _Parser().parse_args()
+    log = lsst.log.Log.getLogger("add_gen3_repo")
+
+    # To convert consistently, don't use any previous output
+    dataset = ap_verify.dataset.Dataset(args.dataset)
+    gen3_repo = os.path.join(dataset.datasetRoot, "preloaded")
+    if os.path.exists(gen3_repo):
+        log.warn("Clearing out %s and making it from scratch...", gen3_repo)
+        shutil.rmtree(gen3_repo)
+    os.makedirs(gen3_repo)
+
+    mode = "copy" if args.drop_gen2 else "relsymlink"
+
+    log.info("Converting templates...")
+    gen2_templates = dataset.templateLocation
+    _migrate_gen2_to_gen3(dataset, gen2_templates, None, gen3_repo, mode,
+                          config_file="convertRepo_templates.py")
+
+    log.info("Converting calibs...")
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = ap_verify.workspace.Workspace(tmp)
+        ap_verify.ingestion.ingestDataset(dataset, workspace)
+
+        gen2_repo = workspace.dataRepo
+        gen2_calibs = workspace.calibRepo
+        # Files stored in the Gen 2 part of the dataset, can be safely linked
+        _migrate_gen2_to_gen3(dataset, gen2_repo, gen2_calibs, gen3_repo, mode,
+                              config_file="convertRepo_calibs.py")
+        # Our refcats and defects are temporary files, and must not be linked
+        _migrate_gen2_to_gen3(dataset, gen2_repo, gen2_calibs, gen3_repo, mode="copy",
+                              config_file="convertRepo_copied.py")
+
+    log.info("Exporting Gen 3 registry to configure new repos...")
+    _export_for_copy(dataset, gen3_repo)
+
+
+def _migrate_gen2_to_gen3(dataset, gen2_repo, gen2_calib_repo, gen3_repo, mode, config_file):
+    """Convert a Gen 2 repository into a Gen 3 repository.
+
+    Parameters
+    ----------
+    dataset : `lsst.ap.verify.dataset.Dataset`
+        The dataset being migrated.
+    gen2_repo, gen2_calib_repo : `str`
+       The locations of the original repositories.
+    gen3_repo : `str`
+       The location of the Gen 3 repository. Must exist, but need not be
+       initialized as a repository.
+    mode : {'relsymlink', 'copy'}
+       Whether the Gen 3 repo should contain symbolic links to the Gen 2
+       datasets, or an independent copy.
+    config_file : `str`
+       The config file (in the dataset config directory) with a configuration
+       for `~lsst.obs.base.gen2to3.ConvertRepoTask`
+    """
+    instrument = _get_instrument_class(dataset.camera)
+    config = os.path.join(dataset.configLocation, config_file)
+
+    # Call convertGepoToGen3 instead of calling ConvertRepoTask directly, to
+    # avoid manually having to do a lot of setup that may change in the future
+    # calib/<instrument>, refcats, and skymaps collections created by default
+    convertGen2RepoToGen3.convert(gen2_repo, gen3_repo, instrument,
+                                  # skymap detected automatically; do nothing
+                                  calibs=gen2_calib_repo,
+                                  config=config,
+                                  transferMode=mode)
+
+
+def _export_for_copy(dataset, repo):
+    """Export a Gen 3 repository so that a dataset can make copies later.
+
+    Parameters
+    ----------
+    dataset : `lsst.ap.verify.dataset.Dataset`
+        The dataset needing the ability to copy the repository.
+    repo : `str`
+        The location of the Gen 3 repository.
+    """
+    butler = daf_butler.Butler(repo)
+    with butler.export(directory=dataset.configLocation, format="yaml") as contents:
+        contents.saveDatasets(butler.registry.queryDatasets(datasetType=..., collections=..., expand=True))
+
+
+def _get_instrument_class(instrument):
+    """Convert a Gen 2 instrument name to a Gen 3 instrument class.
+
+    Parameters
+    ----------
+    instrument : `str`
+        A name in the format returned by
+        `lsst.obs.base.CameraMapper.getCameraName`.
+
+    Returns
+    -------
+    instrumentClass : `str`
+        The fully-qualified `~lsst.obs.base.Instrument` class for the
+        corresponding instrument.
+    """
+    classes = {
+        "decam": "lsst.obs.decam.DarkEnergyCamera",
+        "hsc": "lsst.obs.subaru.HyperSuprimeCam",
+    }
+
+    try:
+        return classes[instrument]
+    except KeyError:
+        raise ValueError(f"Unsupported instrument {instrument}; consider adding it to the "
+                         "dataset template's add_gen3_repo.py script.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a script that converts all Gen 2 content in the dataset to Gen 3, along with config files the script requires. Since all `ap_verify` datasets are created from this repository, this adds a copy of the script and stub configs to the new dataset. The `script/` directory has already been used by individual datasets to house maintenance code, although this is its first use in `dataset_template`.

For background, Gen 2 `ap_verify` datasets store all their data (except coadded templates) in *uningested* form, as separate directories of raw files, calib files, etc. `ap_verify` creates a new repository and ingests the data as the first step of its processing. From various discussions with AP members, it was decided that, in Gen 3, datasets would provide a pre-ingested repository of everything except raws, and that `ap_verify` would create a new repository from the dataset and ingest the raws there (see [DM-21915](https://jira.lsstcorp.org/browse/DM-21915) for a summary).

In both Gen 2 and Gen 3, the downloaded dataset should not be altered by any Butler operation, to keep us from accidentally committing processed data and to provide a "clean slate" every time `ap_verify` is run. In Gen 3, this means providing an export file that can be used to copy the pre-ingested repository.

To minimize download size, the Gen 3 repository uses relative symbolic links to the data that was already stored for Gen 2. This is not possible for refcats (which were previously stored in `.tar.gz` files) or camera/transmission/defect data (which are imported from outside the dataset during conversion); these are copied instead.