### PR TITLE
DM-24575: Add observational and detector metadata to Registry dimension tables

### DIFF
--- a/scripts/add_gen3_repo.py
+++ b/scripts/add_gen3_repo.py
@@ -118,12 +118,12 @@ def _export_for_copy(dataset, repo):
     butler = daf_butler.Butler(repo)
     with butler.export(directory=dataset.configLocation, format="yaml") as contents:
         # Need all detectors, even those without data, for visit definition
-        contents.saveDataIds(butler.registry.queryDimensions({"detector"}))
+        contents.saveDataIds(butler.registry.queryDataIds({"detector"}).expanded())
         # RepoExport has no safeguards against redundant data
         extraDimensions = set(butler.registry.dimensions.elements).difference(
             {"detector", "instrument", "htm7", "abstract_filter"}
         )
-        contents.saveDatasets(butler.registry.queryDatasets(datasetType=..., collections=..., expand=True),
+        contents.saveDatasets(butler.registry.queryDatasets(datasetType=..., collections=...),
                               elements=extraDimensions)
 
 


### PR DESCRIPTION
This PR copies the script fixes in lsst/ap_verify_testdata#13 to the master conversion script, for future use in converting `ap_verify` datasets.