### PR TITLE
DM-30199: Mark ap_verify dataset files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 *.fits filter=lfs diff=lfs merge=lfs -text
 *.gz filter=lfs diff=lfs merge=lfs -text
 *.fz filter=lfs diff=lfs merge=lfs -text
+
+# Must be updated any time Gen 3 repository is updated, but most changes
+# are not human-meaningful.
+config/export.yaml linguist-generated=true


### PR DESCRIPTION
This PR flags `config/export.yaml` as a machine-generated file. The primary benefit of doing so is that it will no longer appear as reviewable changes in repository updates.