### PR TITLE
DM-33039: Create template dataset management scripts

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,1 @@
+Copyright 2022 University of Washington

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2022 University of Washington
+Copyright 2021-2022 University of Washington

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repo is designed to be used as a template for developing new datasets for i
 
 Datasets must link to the corresponding instrument's obs package; this template is currently set up for using [`obs_lsst`](https://github.com/lsst/obs_lsst/) as a placeholder.
 
+NOTE: many files have hardcoded references to the package name; do a search-and-replace for "ap_verify_dataset_template" before attempting other customizations for your dataset.
+
 Relevant Files and Directories
 ------------------------------
 path                  | description

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Template repo for developing datasets for use with ap_verify.
 
 This repo is designed to be used as a template for developing new datasets for integration into [`ap_verify`](https://github.com/lsst/ap_verify/).
 
-Datasets must link to the corresponding instrument's obs package; this template is currently set up for using [`obs_test`](https://github.com/lsst/obs_test/) as a placeholder.
+Datasets must link to the corresponding instrument's obs package; this template is currently set up for using [`obs_lsst`](https://github.com/lsst/obs_lsst/) as a placeholder.
 
 Relevant Files and Directories
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ path                  | description
 `config`              | To be populated with dataset-specific configs. Currently empty.
 `pipelines`           | To be populated with dataset-specific pipelines. Currently contains three example files specialized for ImSim data.
 `preloaded`           | To be populated with a Gen 3 Butler repository (see below). This repository must never be written to; instead, it should be copied to a separate location before use (this is handled automatically by `ap_verify`, see below).
+`scripts`             | Contains example scripts for populating `raw` and/or `preloaded`. Scripts may need to be specialized for a particular dataset before use.
 `dataIds.list`        | List of dataIds in this repo. For use in running Tasks. Currently set to run all Ids.
 
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,3 +13,4 @@ Contents
 path                  | description
 :---------------------|:-----------------------------
 make_empty_repo.sh    | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
+import_templates.py   | Transfer templates from another repo (such as `repo/main`) and register them in `preloaded/`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,14 @@
+Dataset management script templates
+===================================
+
+This directory has example scripts for (re)creating an ap_verify dataset.
+Adopting such scripts for your own datasets is highly recommended, to make it easy to update the pipeline inputs (in particular, calibs and templates) for pipeline improvements.
+These scripts are *not* intended to be used as-is; they may require some fine-tuning to adapt to the specifics of your data set.
+
+As with the rest of the ap_verify_dataset_template repository, there may be hard-coded references to the package in the scripts themselves.
+Be sure to update any such references before proceeding.
+
+Contents
+--------
+path                  | description
+:---------------------|:-----------------------------

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,3 +12,4 @@ Contents
 --------
 path                  | description
 :---------------------|:-----------------------------
+make_empty_repo.sh    | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,3 +17,4 @@ make_empty_repo.sh    | Replace `preloaded/` with a repo containing only dimensi
 import_templates.py   | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
 import_calibs.py      | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`. Calibs are assumed to be generated as part of the regular reprocessing of the source repo, and there's no script for making them from scratch.
 ingest_refcats.py     | Transfer refcats from an external repo (such a `repo/main`) and register them in `preloaded/`.
+get_ephemerides.py    | Download solar system ephemerides and register them in `preloaded/`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,9 +5,6 @@ This directory has example scripts for (re)creating an ap_verify dataset.
 Adopting such scripts for your own datasets is highly recommended, to make it easy to update the pipeline inputs (in particular, calibs and templates) for pipeline improvements.
 These scripts are *not* intended to be used as-is; they may require some fine-tuning to adapt to the specifics of your data set.
 
-As with the rest of the ap_verify_dataset_template repository, there may be hard-coded references to the package in the scripts themselves.
-Be sure to update any such references before proceeding.
-
 The scripts are designed to be modular, and can be called either all at once (through `make_all.sh`), or individually.
 See each script's docstring for usage instructions; those scripts that take arguments also support `--help`.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,3 +15,4 @@ path                  | description
 generate_templates.sh | Create templates in an external repo (such as `repo/main`) that cover this dataset's area.
 make_empty_repo.sh    | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
 import_templates.py   | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
+import_calibs.py      | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`. Calibs are assumed to be generated as part of the regular reprocessing of the source repo, and there's no script for making them from scratch.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,10 +8,14 @@ These scripts are *not* intended to be used as-is; they may require some fine-tu
 As with the rest of the ap_verify_dataset_template repository, there may be hard-coded references to the package in the scripts themselves.
 Be sure to update any such references before proceeding.
 
+The scripts are designed to be modular, and can be called either all at once (through `make_all.sh`), or individually.
+See each script's docstring for usage instructions; those scripts that take arguments also support `--help`.
+
 Contents
 --------
 path                     | description
 :------------------------|:-----------------------------
+make_all.sh              | Rebuild everything from scratch.
 generate_templates.sh    | Create templates in an external repo (such as `repo/main`) that cover this dataset's area.
 make_empty_repo.sh       | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
 import_templates.py      | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,3 +16,4 @@ generate_templates.sh | Create templates in an external repo (such as `repo/main
 make_empty_repo.sh    | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
 import_templates.py   | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
 import_calibs.py      | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`. Calibs are assumed to be generated as part of the regular reprocessing of the source repo, and there's no script for making them from scratch.
+ingest_refcats.py     | Transfer refcats from an external repo (such a `repo/main`) and register them in `preloaded/`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,5 +12,6 @@ Contents
 --------
 path                  | description
 :---------------------|:-----------------------------
+generate_templates.sh | Create templates in an external repo (such as `repo/main`) that cover this dataset's area.
 make_empty_repo.sh    | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
-import_templates.py   | Transfer templates from another repo (such as `repo/main`) and register them in `preloaded/`.
+import_templates.py   | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,11 +10,12 @@ Be sure to update any such references before proceeding.
 
 Contents
 --------
-path                  | description
-:---------------------|:-----------------------------
-generate_templates.sh | Create templates in an external repo (such as `repo/main`) that cover this dataset's area.
-make_empty_repo.sh    | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
-import_templates.py   | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
-import_calibs.py      | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`. Calibs are assumed to be generated as part of the regular reprocessing of the source repo, and there's no script for making them from scratch.
-ingest_refcats.py     | Transfer refcats from an external repo (such a `repo/main`) and register them in `preloaded/`.
-get_ephemerides.py    | Download solar system ephemerides and register them in `preloaded/`.
+path                     | description
+:------------------------|:-----------------------------
+generate_templates.sh    | Create templates in an external repo (such as `repo/main`) that cover this dataset's area.
+make_empty_repo.sh       | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
+import_templates.py      | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
+import_calibs.py         | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`. Calibs are assumed to be generated as part of the regular reprocessing of the source repo, and there's no script for making them from scratch.
+ingest_refcats.py        | Transfer refcats from an external repo (such a `repo/main`) and register them in `preloaded/`.
+get_ephemerides.py       | Download solar system ephemerides and register them in `preloaded/`.
+make_preloaded_export.py | Create an export file of `preloaded/` that's compatible with `butler import`.

--- a/scripts/generate_templates.sh
+++ b/scripts/generate_templates.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Script for automatically generating differencing templates for this dataset.
+# It takes roughly 5 hours to run on lsst-devl.
+# Running this script allows for templates to incorporate pipeline
+# improvements. It makes no attempt to update the set of input exposures; they
+# are hard-coded into the file.
+#
+# Example:
+# $ nohup generate_templates_gen3.sh -c "u/me/DM-123456-calib" -o "u/me/DM-123456-template" &
+# produces templates in /repo/main in the u/me/DM-123456-template collection.
+# See generate_templates_gen3.sh -h for more options.
+
+
+# Abort script on any error
+set -e
+
+
+########################################
+# Raw template exposures to process
+
+# Exposure filter is a safeguard against queries that can't be constrained by
+# tract/patch, or against inclusion of non-HiTS data. Patch filter specifies
+# the area covered by the CI dataset in the hsc_rings_v1 skymap.
+
+FIELDS="'Blind14A_09', 'Blind14A_10'"
+EXPOSURES="288934, 288935, 288975, 288976, 289015, 289016, 289055, 289056, 289160, 289161, 289201,
+           289202, 289242, 289243, 289283, 289284, 289367, 289368, 289408, 289409, 289449, 289450,
+           289492, 289493, 289572, 289573, 289613, 289614, 289655, 289656, 289696, 289697, 289782,
+           289783, 289818, 289820, 289828, 289870, 289871, 289912, 289913"
+declare -A PATCHES
+PATCHES[8363]="76..79"
+PATCHES[8604]="1, 2, 3, 10, 11, 12, 20, 21"
+DATE_CUTOFF=20141231
+
+
+########################################
+# Command-line options
+
+print_error() {
+    >&2 echo "$@"
+}
+
+usage() {
+    print_error
+    print_error "Usage: $0 [-b BUTLER_REPO] -c ROOT_COLLECTION [-h]"
+    print_error
+    print_error "Specific options:"
+    print_error "   -b          Butler repo URI, defaults to /repo/main"
+    print_error "   -c          input calib collection for template processing"
+    print_error "   -o          template collection name; will also appear in final repo"
+    print_error "   -h          show this message"
+    exit 1
+}
+
+parse_args() {
+    while getopts "b:c:o:h" option $@; do
+        case "$option" in
+            b)  BUTLER_REPO="$OPTARG";;
+            c)  CALIBS="$OPTARG";;
+            o)  TEMPLATES="$OPTARG";;
+            h)  usage;;
+            *)  usage;;
+        esac
+    done
+    if [[ -z "${BUTLER_REPO}" ]]; then
+        BUTLER_REPO="/repo/main"
+    fi
+    if [[ -z "${CALIBS}" ]]; then
+        print_error "$0: mandatory argument -- c"
+        usage
+        exit 1
+    fi
+    if [[ -z "${TEMPLATES}" ]]; then
+        print_error "$0: mandatory argument -- o"
+        usage
+        exit 1
+    fi
+}
+parse_args "$@"
+
+
+########################################
+# Generate templates
+
+FILTER="instrument='DECam' AND skymap='hsc_rings_v1'
+        AND exposure IN (${EXPOSURES}) AND detector NOT IN (2, 61)
+        AND ("
+OR=""
+for tract in ${!PATCHES[*]}; do
+    FILTER="${FILTER} ${OR} (tract=${tract} AND patch IN (${PATCHES[${tract}]}))"
+    OR="OR"
+done
+FILTER="${FILTER})"
+
+
+pipetask run -j 12 -d "${FILTER}" -b ${BUTLER_REPO} -i DECam/defaults,${CALIBS} -o ${TEMPLATES} \
+    -p $AP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
+
+# Run single-frame processing and coaddition separately, so that isolated
+# errors in SFP do not prevent coaddition from running. Instead, coadds will
+# use all successful runs, ignoring any failures.
+pipetask run -j 12 -d "${FILTER}" -b ${BUTLER_REPO} -o ${TEMPLATES} \
+    -p $AP_VERIFY_CI_HITS2015_DIR/pipelines/ApTemplate.yaml#singleFrameAp
+pipetask run -j 12 -d "${FILTER}" -b ${BUTLER_REPO} -o ${TEMPLATES} \
+    -p $AP_VERIFY_CI_HITS2015_DIR/pipelines/ApTemplate.yaml#makeTemplate
+
+
+########################################
+# Final summary
+
+echo "Templates stored in ${BUTLER_REPO}:${TEMPLATES}"

--- a/scripts/generate_templates.sh
+++ b/scripts/generate_templates.sh
@@ -39,7 +39,8 @@ set -e
 ########################################
 # Raw template exposures to process
 
-PIPELINE="${AP_VERIFY_DATASET_TEMPLATE_DIR}/pipelines/ApTemplate.yaml"
+SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
+PIPELINE="${SCRIPT_DIR}/../pipelines/ApTemplate.yaml"
 INSTRUMENT=LSSTCam
 DEFAULT_COLLECTION=${INSTRUMENT}/defaults
 SKYMAP=latiss_v1

--- a/scripts/get_ephemerides.py
+++ b/scripts/get_ephemerides.py
@@ -39,7 +39,7 @@ import tempfile
 
 import lsst.log
 import lsst.sphgeom
-from lsst.daf.butler import Butler
+from lsst.daf.butler import Butler, CollectionType
 import lsst.obs.base
 
 
@@ -54,6 +54,7 @@ RAW_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "raw"))
 RAW_RUN = "raw"
 EPHEM_DATASET = "visitSsObjects"
 DEST_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "preloaded"))
+DEST_COLLECTION = "sso"
 DEST_RUN = "sso/cached"
 
 
@@ -214,5 +215,7 @@ with tempfile.TemporaryDirectory() as workspace:
     preloaded = Butler(DEST_DIR, writeable=True)
     logging.info("Transferring ephemerides to dataset...")
     _transfer_ephems(EPHEM_DATASET, temp_repo, workspace, DEST_RUN, preloaded)
+preloaded.registry.registerCollection(DEST_COLLECTION, CollectionType.CHAINED)
+preloaded.registry.setCollectionChain(DEST_COLLECTION, [DEST_RUN])
 
-logging.info("Solar system catalogs copied to %s:%s", DEST_DIR, DEST_RUN)
+logging.info("Solar system catalogs copied to %s:%s", DEST_DIR, DEST_COLLECTION)

--- a/scripts/get_ephemerides.py
+++ b/scripts/get_ephemerides.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# This file is part of ap_verify_ci_hits2015.
+# This file is part of ap_verify_dataset_template.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project
@@ -25,6 +25,9 @@ fields and observation times.
 
 Running this script allows for updates to the ephemerides to be incorporated
 into the dataset.
+
+This script takes no command-line arguments; it infers everything it needs from
+the `preloaded/` repository.
 """
 
 import glob
@@ -36,7 +39,7 @@ import tempfile
 
 import lsst.log
 import lsst.sphgeom
-from lsst.daf.butler import Butler, FileDataset
+from lsst.daf.butler import Butler
 import lsst.obs.base
 
 
@@ -46,11 +49,11 @@ lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
 
 # Avoid explicit references to dataset package to maximize portability.
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
-PIPE_DIR = os.path.join(SCRIPT_DIR, "..", "pipelines")
-RAW_DIR = os.path.join(SCRIPT_DIR, "..", "raw")
+PIPE_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "pipelines"))
+RAW_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "raw"))
 RAW_RUN = "raw"
 EPHEM_DATASET = "visitSsObjects"
-DEST_DIR = os.path.join(SCRIPT_DIR, "..", "preloaded")
+DEST_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "preloaded"))
 DEST_RUN = "sso/cached"
 
 
@@ -113,12 +116,10 @@ def _ingest_raws(repo, raw_dir, run):
         The name of the run into which to import the raws.
     """
     raws = glob.glob(os.path.join(raw_dir, '**', '*.fits.fz'), recursive=True)
-    # explicit config workaround for DM-971
-    ingester = lsst.obs.base.RawIngestTask(butler=repo, config=lsst.obs.base.RawIngestConfig())
+    ingester = lsst.obs.base.RawIngestTask(butler=repo)
     ingester.run(raws, run=run)
     exposures = set(repo.registry.queryDataIds(["exposure"]))
-    # explicit config workaround for DM-971
-    definer = lsst.obs.base.DefineVisitsTask(butler=repo, config=lsst.obs.base.DefineVisitsConfig())
+    definer = lsst.obs.base.DefineVisitsTask(butler=repo)
     definer.run(exposures)
 
 

--- a/scripts/get_ephemerides.py
+++ b/scripts/get_ephemerides.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Script for downloading solar system object ephemerides for this dataset's
+fields and observation times.
+
+Running this script allows for updates to the ephemerides to be incorporated
+into the dataset.
+"""
+
+import glob
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+
+import lsst.log
+import lsst.sphgeom
+from lsst.daf.butler import Butler, FileDataset
+import lsst.obs.base
+
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+
+# Avoid explicit references to dataset package to maximize portability.
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+PIPE_DIR = os.path.join(SCRIPT_DIR, "..", "pipelines")
+RAW_DIR = os.path.join(SCRIPT_DIR, "..", "raw")
+RAW_RUN = "raw"
+EPHEM_DATASET = "visitSsObjects"
+DEST_DIR = os.path.join(SCRIPT_DIR, "..", "preloaded")
+DEST_RUN = "sso/cached"
+
+
+########################################
+# Set up temp repository
+
+def _get_instruments(repo_dir):
+    """Find all instruments supported by a repository.
+
+    Parameters
+    ----------
+    repo_dir : `str`
+        The repository to search for instruments.
+
+    Returns
+    -------
+    instruments : `list` [`lsst.obs.base.Instrument`]
+    """
+    registry = Butler(repo_dir, writeable=False).registry
+    ids = registry.queryDataIds("instrument")
+    return [lsst.obs.base.Instrument.fromName(id["instrument"], registry) for id in ids]
+
+
+def _make_repo_with_instruments(repo_dir, instruments):
+    """Create a repository and populate it with instrument registrations from
+    an existing repository.
+
+    Parameters
+    ----------
+    repo_dir : `str`
+        The directory in which to create the new repository.
+    instrument : iterable [`lsst.obs.base.Instrument`]
+        The instruments to register in the new repository.
+
+    Returns
+    -------
+    butler : `lsst.daf.butler.Butler`
+        A writeable Butler to the new repo.
+    """
+    config = Butler.makeRepo(repo_dir)
+    repo = Butler(config, writeable=True)
+    for instrument in instruments:
+        instrument.register(repo.registry)
+    return repo
+
+
+########################################
+# Ingest raws (needed for visitinfo)
+
+def _ingest_raws(repo, raw_dir, run):
+    """Ingest this dataset's raws into a specific repo.
+
+    Parameters
+    ---------
+    repo : `lsst.daf.butler.Butler`
+        A writeable Butler for the repository to ingest into.
+    raw_dir : `str`
+        The directory containing raw files.
+    run : `str`
+        The name of the run into which to import the raws.
+    """
+    raws = glob.glob(os.path.join(raw_dir, '**', '*.fits.fz'), recursive=True)
+    # explicit config workaround for DM-971
+    ingester = lsst.obs.base.RawIngestTask(butler=repo, config=lsst.obs.base.RawIngestConfig())
+    ingester.run(raws, run=run)
+    exposures = set(repo.registry.queryDataIds(["exposure"]))
+    # explicit config workaround for DM-971
+    definer = lsst.obs.base.DefineVisitsTask(butler=repo, config=lsst.obs.base.DefineVisitsConfig())
+    definer.run(exposures)
+
+
+########################################
+# Download ephemerides
+
+def _get_ephem(repo_dir, raw_collection, ephem_collection):
+    """Run the task for downloading ephemerides.
+
+    Parameters
+    ----------
+    repo_dir : `str`
+        The repository on which to run the task.
+    raw_collection : `str`
+        The collection containing input raws.
+    ephem_collection : `str`
+        The collection into which to generate ephemerides.
+
+    Raises
+    ------
+    RuntimeError
+        Raised on any pipeline failure.
+    """
+    pipeline_file = os.path.join(PIPE_DIR, "Ephemerides.yaml")
+    pipeline_args = ["pipetask", "run",
+                     "--butler-config", repo_dir,
+                     "--pipeline", pipeline_file,
+                     "--input", raw_collection,
+                     "--output-run", ephem_collection,
+                     "--processes", "12",
+                     "--register-dataset-types",
+                     ]
+    results = subprocess.run(pipeline_args, capture_output=False, shell=False, check=False)
+    if results.returncode:
+        raise RuntimeError("Pipeline failed to run; see log for details.")
+
+
+########################################
+# Import/export
+
+def _transfer_ephems(ephem_type, src_repo, src_dir, run, dest_repo):
+    """Copy ephemerides between two repositories.
+
+    Parameters
+    ----------
+    ephem_type : `str`
+        The dataset type of the ephemerides.
+    src_repo : `lsst.daf.butler.Butler`
+        The repository from which to copy the datasets.
+    src_dir : `str`
+        The location of ``src_repo``.
+    run : `str`
+        The name of the run containing the ephemerides in both ``src_repo``
+        and ``dest_repo``.
+    dest_repo : `lsst.daf.butler.Butler`
+        The repository to which to copy the datasets.
+    """
+    # Need to transfer visit definitions as well; Butler.export is the easiest
+    # way to do this.
+    with tempfile.NamedTemporaryFile(suffix=".yaml") as export_file:
+        with src_repo.export(filename=export_file.name, transfer=None) as contents:
+            contents.saveDatasets(src_repo.registry.queryDatasets(ephem_type, collections=run),
+                                  elements=["visit"])
+            # Because of how the temp repo was constructed, there should not be
+            # any visit/exposure records other than those needed to support the
+            # ephemerides datasets.
+            contents.saveDimensionData("visit_system",
+                                       src_repo.registry.queryDimensionRecords("visit_system"))
+            contents.saveDimensionData("visit",
+                                       src_repo.registry.queryDimensionRecords("visit"))
+            contents.saveDimensionData("exposure",
+                                       src_repo.registry.queryDimensionRecords("exposure"))
+            contents.saveDimensionData("visit_definition",
+                                       src_repo.registry.queryDimensionRecords("visit_definition"))
+            contents.saveDimensionData("visit_detector_region",
+                                       src_repo.registry.queryDimensionRecords("visit_detector_region"))
+            # runs included automatically by saveDatasets
+        dest_repo.import_(directory=src_dir, filename=export_file.name, transfer="copy")
+
+
+########################################
+# Put everything together
+
+logging.info("Creating temporary repository...")
+with tempfile.TemporaryDirectory() as workspace:
+    temp_repo = _make_repo_with_instruments(workspace, _get_instruments(DEST_DIR))
+    logging.info("Ingesting raws...")
+    _ingest_raws(temp_repo, RAW_DIR, RAW_RUN)
+    logging.info("Downloading ephemerides...")
+    _get_ephem(workspace, RAW_RUN, DEST_RUN)
+    temp_repo.registry.refresh()    # Pipeline added dataset types
+    preloaded = Butler(DEST_DIR, writeable=True)
+    logging.info("Transferring ephemerides to dataset...")
+    _transfer_ephems(EPHEM_DATASET, temp_repo, workspace, DEST_RUN, preloaded)
+
+logging.info("Solar system catalogs copied to %s:%s", DEST_DIR, DEST_RUN)

--- a/scripts/import_calibs.py
+++ b/scripts/import_calibs.py
@@ -22,10 +22,14 @@
 
 """Script for copying calibs appropriate for these exposures.
 
+This script currently requires that the calibration collection be part of a
+chained collection, so that it can query the latter to identify the subset of
+calibs to export. This restriction should go away after DM-37409.
+
 Example:
-$ python import_calibs.py -c "u/me/DM-123456-calib"
-imports image calibrations from u/me/DM-123456-calib in /repo/dc2 to
-calibs in this dataset's preloaded repo.
+$ python import_calibs.py -c "u/me/DM-123456-calib-chain"
+imports image calibrations from (the calibration collections in)
+u/me/DM-123456-calib in /repo/main to calibs in this dataset's preloaded repo.
 """
 
 import argparse
@@ -51,7 +55,7 @@ def _make_parser():
     parser.add_argument("-b", dest="src_dir", default="/repo/dc2",
                         help="Repo to import from, defaults to '/repo/dc2'.")
     parser.add_argument("-c", dest="src_collection", required=True,
-                        help="Calib collection to import from.")
+                        help="Calib collection to import from. Must be a chained collection before DM-37409.")
     return parser
 
 
@@ -66,7 +70,6 @@ DATA_IDS = [dict(detector=164, visit=982985, physical_filter="r_sim_1.4", instru
 CALIB_NAMES = ("bias", "dark", "flat")
 CALIB_COLLECTION = "LSSTCam-imSim/calib"
 DATASET_REPO = os.path.join(os.environ["AP_VERIFY_CI_DC2_DIR"], "preloaded")
-ORIGINAL_CALIB_COLLECTION = "2.2i/calib/gen2"
 
 
 def _export(butler, export_file):
@@ -82,8 +85,8 @@ def _export(butler, export_file):
 
     Returns
     -------
-    runs : iterable [`str`]
-        The names of the runs containing exported templates.
+    calib_collections : iterable [`str`]
+        The names of the calibration collections containing validities.
     """
     with butler.export(filename=export_file, transfer=None) as contents:
         for name in CALIB_NAMES:
@@ -91,11 +94,43 @@ def _export(butler, export_file):
                 calibs = butler.registry.queryDatasets(name, dataId=data_id, collections=butler.collections)
                 contents.saveDatasets(calibs)
 
-        contents.saveCollection(ORIGINAL_CALIB_COLLECTION)
-        # Do not save butler.collections -- if they are RUN collections, it's
-        # redundant; if they are CHAINED, they likely contain content that
-        # isn't being transferred.
-        return {c.run for c in calibs}
+        calib_collections = set()
+        for collection in butler.collections:
+            calib_collections.update(_save_validities(butler.registry, contents, collection))
+        return calib_collections
+
+
+def _save_validities(registry, exporter, collection):
+    """Transfer the validity information found in a collection or any of its
+    sub-collections.
+
+    This function is guaranteed not to add any datasets to the exporter.
+
+    Parameters
+    ----------
+    registry : `lsst.daf.butler.Registry`
+        The registry managing the collections.
+    exporter : `lsst.daf.butler.transfers.RepoExportContext`
+        The export manager to which to copy validities.
+    collection : `str`
+        The collection from which to copy validities.
+
+    Returns
+    -------
+    calib_collections : iterable [`str`]
+        All the individual calibration collections that were exported.
+    """
+    match registry.getCollectionType(collection):
+        case CollectionType.CALIBRATION:
+            exporter.saveCollection(collection)
+            return {collection}
+        case CollectionType.CHAINED:
+            calib_collections = set()
+            for child in registry.getCollectionChain(collection):
+                calib_collections.update(_save_validities(registry, exporter, child))
+            return calib_collections
+        case _:
+            return []
 
 
 def _import(butler, export_file, base_dir):
@@ -115,12 +150,12 @@ def _import(butler, export_file, base_dir):
 
 with tempfile.NamedTemporaryFile(suffix=".yaml") as export_file:
     src = Butler(args.src_dir, collections=args.src_collection, writeable=False)
-    runs = _export(src, export_file.name)
+    calib_collections = _export(src, export_file.name)
     dest = Butler(DATASET_REPO, writeable=True)
     _import(dest, export_file.name, args.src_dir)
     dest.registry.registerCollection(CALIB_COLLECTION, CollectionType.CHAINED)
     chain = list(dest.registry.getCollectionChain(CALIB_COLLECTION))
-    chain.insert(0, ORIGINAL_CALIB_COLLECTION)
+    chain.extend(calib_collections)
     dest.registry.setCollectionChain(CALIB_COLLECTION, chain)
 
 logging.info(f"Calibs stored in {DATASET_REPO}:{CALIB_COLLECTION}.")

--- a/scripts/import_calibs.py
+++ b/scripts/import_calibs.py
@@ -53,7 +53,9 @@ DATA_IDS = [dict(detector=164, visit=982985, instrument="LSSTCam"),
             ]
 CALIB_NAMES = ["bias", "dark", "flat"]
 
-DATASET_REPO = os.path.join(os.environ["AP_VERIFY_DATASET_TEMPLATE_DIR"], "preloaded")
+# Avoid explicit references to dataset package to maximize portability.
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+DATASET_REPO = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "preloaded"))
 DATASET_CALIB_COLLECTION = "LSSTCam/calib"
 
 

--- a/scripts/import_calibs.py
+++ b/scripts/import_calibs.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# This file is part of ap_verify_ci_dc2.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Script for copying calibs appropriate for these exposures.
+
+Example:
+$ python import_calibs.py -c "u/me/DM-123456-calib"
+imports image calibrations from u/me/DM-123456-calib in /repo/dc2 to
+calibs in this dataset's preloaded repo.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+
+import lsst.log
+import lsst.skymap
+from lsst.daf.butler import Butler, CollectionType
+
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+
+########################################
+# Command-line options
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", dest="src_dir", default="/repo/dc2",
+                        help="Repo to import from, defaults to '/repo/dc2'.")
+    parser.add_argument("-c", dest="src_collection", required=True,
+                        help="Calib collection to import from.")
+    return parser
+
+
+args = _make_parser().parse_args()
+
+
+########################################
+# Export/Import
+
+DATA_IDS = [dict(detector=164, visit=982985, physical_filter="r_sim_1.4", instrument="LSSTCam-imSim"),
+            dict(detector=168, visit=943296, physical_filter="r_sim_1.4", instrument="LSSTCam-imSim")]
+CALIB_NAMES = ("bias", "dark", "flat")
+CALIB_COLLECTION = "LSSTCam-imSim/calib"
+DATASET_REPO = os.path.join(os.environ["AP_VERIFY_CI_DC2_DIR"], "preloaded")
+ORIGINAL_CALIB_COLLECTION = "2.2i/calib/gen2"
+
+
+def _export(butler, export_file):
+    """Export the files to be copied.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler pointing to the repository and collection(s) to be
+        exported from.
+    export_file : `str`
+        A path pointing to a file to contain the export results.
+
+    Returns
+    -------
+    runs : iterable [`str`]
+        The names of the runs containing exported templates.
+    """
+    with butler.export(filename=export_file, transfer=None) as contents:
+        for name in CALIB_NAMES:
+            for data_id in DATA_IDS:
+                calibs = butler.registry.queryDatasets(name, dataId=data_id, collections=butler.collections)
+                contents.saveDatasets(calibs)
+
+        contents.saveCollection(ORIGINAL_CALIB_COLLECTION)
+        # Do not save butler.collections -- if they are RUN collections, it's
+        # redundant; if they are CHAINED, they likely contain content that
+        # isn't being transferred.
+        return {c.run for c in calibs}
+
+
+def _import(butler, export_file, base_dir):
+    """Import the exported files.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler pointing to the dataset repository.
+    export_file : `str`
+        A path pointing to a file containing the export results.
+    base_dir : `str`
+        The base directory for the file locations in ``export_file``.
+    """
+    butler.import_(directory=base_dir, filename=export_file, transfer="copy")
+
+
+with tempfile.NamedTemporaryFile(suffix=".yaml") as export_file:
+    src = Butler(args.src_dir, collections=args.src_collection, writeable=False)
+    runs = _export(src, export_file.name)
+    dest = Butler(DATASET_REPO, writeable=True)
+    _import(dest, export_file.name, args.src_dir)
+    dest.registry.registerCollection(CALIB_COLLECTION, CollectionType.CHAINED)
+    chain = list(dest.registry.getCollectionChain(CALIB_COLLECTION))
+    chain.insert(0, ORIGINAL_CALIB_COLLECTION)
+    dest.registry.setCollectionChain(CALIB_COLLECTION, chain)
+
+logging.info(f"Calibs stored in {DATASET_REPO}:{CALIB_COLLECTION}.")

--- a/scripts/import_templates.py
+++ b/scripts/import_templates.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Script for copying templates appropriate for these fields.
+
+The datasets can be from any source, including the generate_templates_gen3.sh
+script in this directory.
+
+Example:
+$ python import_templates_gen3.py -t "u/me/DM-123456-template"
+imports deep templates from u/me/DM-123456-template in /repo/main to
+templates/deep in this dataset's preloaded repo. See
+generate_templates_gen3.sh -h for more options.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+
+import lsst.log
+import lsst.skymap
+from lsst.daf.butler import Butler, CollectionType
+
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+
+########################################
+# Command-line options
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", dest="src_dir", default="/repo/main",
+                        help="Repo to import from, defaults to '/repo/main'.")
+    parser.add_argument("-t", dest="src_collection", required=True,
+                        help="Template collection to import from.")
+    return parser
+
+
+args = _make_parser().parse_args()
+
+
+########################################
+# Export/Import
+
+TEMPLATE_TYPE = "deep"
+TEMPLATE_NAME = TEMPLATE_TYPE + "Coadd"
+TEMPLATE_COLLECT = "templates/" + TEMPLATE_TYPE
+DATASET_REPO = os.path.join(os.environ["AP_VERIFY_CI_HITS2015_DIR"], "preloaded")
+
+
+def _export(butler, export_file):
+    """Export the files to be copied.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler pointing to the repository and collection(s) to be
+        exported from.
+    export_file : `str`
+        A path pointing to a file to contain the export results.
+
+    Returns
+    -------
+    runs : iterable [`str`]
+        The names of the runs containing exported templates.
+    """
+    skymaps = butler.registry.queryDataIds("skymap", datasets=TEMPLATE_NAME, collections=butler.collections)
+    skymap_query = f"skymap IN ({', '.join(repr(id['skymap']) for id in skymaps)})"
+    with butler.export(filename=export_file, transfer=None) as contents:
+        contents.saveDatasets(
+            butler.registry.queryDatasets(
+                "skyMap", collections=lsst.skymap.BaseSkyMap.SKYMAP_RUN_COLLECTION_NAME,
+                findFirst=True, where=skymap_query),
+            elements=set())
+        templates = butler.registry.queryDatasets(TEMPLATE_NAME, collections=butler.collections,
+                                                  findFirst=True)
+        contents.saveDatasets(templates)
+        # Do not save butler.collections -- if they are RUN collections, it's
+        # redundant; if they are CHAINED, they likely contain content that
+        # isn't being transferred.
+        return {t.run for t in templates}
+
+
+def _import(butler, export_file, base_dir):
+    """Import the exported files.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler pointing to the dataset repository.
+    export_file : `str`
+        A path pointing to a file containing the export results.
+    base_dir : `str`
+        The base directory for the file locations in ``export_file``.
+    """
+    butler.import_(directory=base_dir, filename=export_file, transfer="copy")
+
+
+with tempfile.NamedTemporaryFile(suffix=".yaml") as export_file:
+    src = Butler(args.src_dir, collections=args.src_collection, writeable=False)
+    runs = _export(src, export_file.name)
+    dest = Butler(DATASET_REPO, writeable=True)
+    _import(dest, export_file.name, args.src_dir)
+    dest.registry.registerCollection(TEMPLATE_COLLECT, CollectionType.CHAINED)
+    dest.registry.setCollectionChain(TEMPLATE_COLLECT, runs)
+
+logging.info(f"Templates stored in {DATASET_REPO}:{TEMPLATE_COLLECT}.")

--- a/scripts/import_templates.py
+++ b/scripts/import_templates.py
@@ -49,7 +49,9 @@ lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
 
 # Template type **must** match that used in the dataset's pipelines, including ApTemplate.yaml if it exists.
 TEMPLATE_TYPE = "goodSeeing"
-DATASET_REPO = os.path.join(os.environ["AP_VERIFY_DATASET_TEMPLATE_DIR"], "preloaded")
+# Avoid explicit references to dataset package to maximize portability.
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+DATASET_REPO = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "preloaded"))
 
 
 ########################################

--- a/scripts/import_templates.py
+++ b/scripts/import_templates.py
@@ -47,7 +47,7 @@ logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
 
 
-# Template type **must** match that used in the dataset's pipelines.
+# Template type **must** match that used in the dataset's pipelines, including ApTemplate.yaml if it exists.
 TEMPLATE_TYPE = "goodSeeing"
 DATASET_REPO = os.path.join(os.environ["AP_VERIFY_DATASET_TEMPLATE_DIR"], "preloaded")
 

--- a/scripts/ingest_refcats.py
+++ b/scripts/ingest_refcats.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Script for copying standard refcats that cover this dataset's fields.
+
+Running this script allows for updates to the refcats to be incorporated
+into the dataset.
+"""
+
+import argparse
+import logging
+import sys
+
+from astropy.coordinates import SkyCoord
+
+import lsst.log
+import lsst.sphgeom
+from lsst.daf.butler import Butler, CollectionType, DatasetRef, DatasetType, FileDataset
+
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+
+########################################
+# Fields and catalogs to process
+
+# Use SkyCoord because it provides built-in sexagecimal and HMS support.
+FIELDS = [SkyCoord("10h00m28.800s", "+02d12m36.00s"),  # field 26 (2014:04)
+          SkyCoord("10h20m28.800s", "-06d31m12.00s"),  # field 40 (2014:10)
+          SkyCoord("10h21m52.800s", "-04d57m00.00s"),  # field 42 (2014:09)
+          ]
+FIELD_RADIUS = 2.0  # degrees
+
+# Key is catalog name in source repo, value is name in ap_verify_ci_hits2015.
+REFCATS = {"gaia_dr2_20200414": "gaia",
+           "ps1_pv3_3pi_20170110": "panstarrs",
+           }
+
+
+########################################
+# Command-line options
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", dest="src_dir", default="/repo/main",
+                        help="Refcat source Butler repo, defaults to '/repo/main'.")
+    parser.add_argument("-i", dest="src_collection", default="refcats",
+                        help="Refcat source collection, defaults to 'refcats'.")
+    return parser
+
+
+args = _make_parser().parse_args()
+
+
+########################################
+# Identify all required shards
+
+HTM_LEVEL = 7
+
+
+def _get_shards(centers, radius):
+    """Return all shards overlapping a set of fields.
+
+    Parameters
+    ----------
+    centers : iterable [`astropy.coordinates.SkyCoord`]
+        The right ascension and declination of the field centers.
+    radius : `float`
+        The radius of each field, in degrees.
+
+    Returns
+    -------
+    shards : iterable [`tuple` [`int`]]
+        The ranges of consecutive HTM indices that overlap any of the fields.
+        Individual ranges may overlap. Each range is represented as a tuple of
+        the lowest and the highest index in the range, inclusive (thus, an
+        isolated index ``i`` is represented by ``(i, i)``).
+    """
+    indexer = lsst.sphgeom.HtmPixelization(HTM_LEVEL)
+    shards = []
+    for center in centers:
+        vector = center.represent_as('cartesian').xyz.value
+        region = lsst.sphgeom.Circle(lsst.sphgeom.UnitVector3d(vector[0], vector[1], vector[2]),
+                                     lsst.sphgeom.Angle.fromDegrees(radius))
+        # Convert from half-open to fully-closed intervals.
+        shards.extend((start, end-1) for (start, end) in indexer.envelope(region))
+    return shards
+
+
+logging.info("Identifying refcat shards...")
+shards = _get_shards(FIELDS, FIELD_RADIUS)
+if not shards:
+    raise RuntimeError("No HTM shards found; coordinates are likely corrupted.")
+logging.debug("%d shard ranges found", len(shards))
+
+
+def _make_range(start, end):
+    """Represent a range of contiguous integers in Butler dimension
+    expression syntax.
+
+    Parameters
+    ----------
+    start, end : `int`
+        The first and last elements of the range, *inclusive*.
+        Assumes ``start <= end``.
+
+    Returns
+    -------
+    range : `str`
+        The Butler syntax for the range.
+    """
+    if start == end:
+        return str(start)
+    else:
+        return f"{start}..{end}"
+
+
+id_ranges = [_make_range(start, end) for (start, end) in shards]
+
+
+########################################
+# Transfer shards
+
+DEST_DIR = "${AP_VERIFY_CI_HITS2015_DIR}/preloaded/"
+STD_REFCAT = "refcats"
+DEST_RUN = "refcats/imported"
+
+
+def _rename_dataset_type(type, name):
+    """Create a DatasetType that differs from an existing one in name only.
+
+    Parameters
+    ---------
+    type : `lsst.daf.butler.DatasetType`
+        The type to rename.
+    name : `str`
+        The new name to adopt.
+
+    Returns
+    -------
+    new_type : `lsst.daf.butler.DatasetType`
+        The new DatasetType.
+    """
+    return DatasetType(name, type.dimensions, type.storageClass, type.parentStorageClass)
+
+
+src_repo = Butler(args.src_dir, collections=args.src_collection, writeable=False)
+dest_repo = Butler(DEST_DIR, run=DEST_RUN, writeable=True)
+
+
+def _remove_refcat_run(butler, run):
+    """Remove a refcat run and any references from a repository.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        The repository from which to remove ``run``.
+    run : `str`
+        The run to remove, if it exists.
+    """
+    try:
+        refcat_runs = butler.registry.getCollectionChain(STD_REFCAT)
+        if run in refcat_runs:
+            new_runs = list(refcat_runs)
+            new_runs.remove(run)
+            butler.registry.setCollectionChain(STD_REFCAT, new_runs)
+    except (lsst.daf.butler.registry.MissingCollectionError, TypeError):
+        pass  # No STD_REFCAT chain; nothing to do
+
+    try:
+        butler.removeRuns([run], unstore=True)
+    except lsst.daf.butler.registry.MissingCollectionError:
+        pass  # Already removed; nothing to do
+
+
+logging.info("Preparing destination repository %s...", DEST_DIR)
+_remove_refcat_run(dest_repo, DEST_RUN)
+dest_repo.registry.registerCollection(DEST_RUN, CollectionType.RUN)
+for src_cat, dest_cat in REFCATS.items():
+    src_type = src_repo.registry.getDatasetType(src_cat)
+    dest_type = _rename_dataset_type(src_type, dest_cat)
+    dest_repo.registry.registerDatasetType(dest_type)
+dest_repo.registry.refresh()
+
+logging.info("Searching for refcats in %s:%s...", args.src_dir, args.src_collection)
+query = f"htm{HTM_LEVEL} in ({','.join(id_ranges)})"
+datasets = []
+for src_ref in src_repo.registry.queryDatasets(REFCATS.keys(), where=query, findFirst=True):
+    src_type = src_ref.datasetType
+    dest_type = _rename_dataset_type(src_type, REFCATS[src_type.name])
+    dest_ref = DatasetRef(dest_type, src_ref.dataId)
+    datasets.append(FileDataset(path=src_repo.getURI(src_ref), refs=dest_ref))
+
+logging.info("Copying refcats...")
+dest_repo.ingest(*datasets, transfer="copy")
+
+logging.info("%d refcat shards copied to %s:%s", len(datasets), DEST_DIR, DEST_RUN)

--- a/scripts/make_all.sh
+++ b/scripts/make_all.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Script for regenerating a complete Gen 3 repository in preloaded/.
+# It takes roughly 10 hours to run on lsst-devl.
+#
+# Example:
+# $ nohup generate_all_gen3.sh -c "u/me/DM-123456" &
+# fills this dataset, using collections prefixed by u/me/DM-123456 in
+# /repo/main as a staging area. See generate_all_gen3.sh -h for more options.
+
+
+# Abort script on any error
+set -e
+
+SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
+DATASET_REPO="${AP_VERIFY_CI_HITS2015_DIR:?'dataset is not set up'}/preloaded/"
+
+
+########################################
+# Command-line options
+
+print_error() {
+    >&2 echo "$@"
+}
+
+usage() {
+    print_error
+    print_error "Usage: $0 [-b BUTLER_REPO] -c ROOT_COLLECTION [-h]"
+    print_error
+    print_error "Specific options:"
+    print_error "   -b          Butler repo URI, defaults to /repo/main"
+    print_error "   -c          unique base collection name for processing; will also appear in final repo"
+    print_error "   -h          show this message"
+    exit 1
+}
+
+parse_args() {
+    while getopts "b:c:h" option $@; do
+        case "$option" in
+            b)  SCRATCH_REPO="$OPTARG";;
+            c)  COLLECT_ROOT="$OPTARG";;
+            h)  usage;;
+            *)  usage;;
+        esac
+    done
+    if [[ -z "${SCRATCH_REPO}" ]]; then
+        SCRATCH_REPO="/repo/main"
+    fi
+    if [[ -z "${COLLECT_ROOT}" ]]; then
+        print_error "$0: mandatory argument -- c"
+        usage
+        exit 1
+    fi
+}
+parse_args $@
+
+
+CALIB_COLLECTION_SCI="${COLLECT_ROOT}-calib-science"
+CALIB_COLLECTION_TMP="${COLLECT_ROOT}-calib-template"
+TEMPLATE_COLLECTION="${COLLECT_ROOT}-template"
+REFCAT_COLLECTION="refcats"
+
+
+########################################
+# Prepare calibs
+
+"${SCRIPT_DIR}/generate_calibs_gen3_science.sh" -b ${SCRATCH_REPO} -c "${CALIB_COLLECTION_SCI}"
+
+
+########################################
+# Prepare templates
+
+"${SCRIPT_DIR}/generate_calibs_gen3_template.sh" -b ${SCRATCH_REPO} -c "${CALIB_COLLECTION_TMP}"
+"${SCRIPT_DIR}/generate_templates_gen3.sh" -b ${SCRATCH_REPO} -c "${CALIB_COLLECTION_TMP}-calib" \
+    -o "${TEMPLATE_COLLECTION}"
+
+
+########################################
+# Repository creation
+
+"${SCRIPT_DIR}/make_preloaded.sh"
+
+
+########################################
+# Import calibs, templates, and refcats
+
+"${SCRIPT_DIR}/import_calibs_gen3.sh" -b ${SCRATCH_REPO} -c "${CALIB_COLLECTION_SCI}-calib"
+python "${SCRIPT_DIR}/import_templates_gen3.py" -b ${SCRATCH_REPO} -t "${TEMPLATE_COLLECTION}"
+python "${SCRIPT_DIR}/generate_refcats_gen3.py" -b ${SCRATCH_REPO} -i "${REFCAT_COLLECTION}"
+
+
+########################################
+# Download solar system ephemerides
+
+python "${SCRIPT_DIR}/generate_ephemerides_gen3.py"
+
+########################################
+# Final clean-up
+
+butler collection-chain "${DATASET_REPO}" refcats refcats/imported
+butler collection-chain "${DATASET_REPO}" sso sso/cached
+butler collection-chain "${DATASET_REPO}" DECam/defaults templates/deep skymaps DECam/calib refcats sso
+python "${SCRIPT_DIR}/make_preloaded_export.py" --dataset ap_verify_ci_hits2015
+
+echo "Gen 3 preloaded repository complete."
+echo "All preloaded data products are accessible through the DECam/defaults collection."

--- a/scripts/make_all.sh
+++ b/scripts/make_all.sh
@@ -37,7 +37,7 @@ set -e
 set -x
 
 SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
-DATASET_REPO="${AP_VERIFY_DATASET_TEMPLATE_DIR:?'dataset is not set up'}/preloaded/"
+DATASET_REPO="${SCRIPT_DIR}/../preloaded/"
 
 INSTRUMENT=LSSTCam
 UMBRELLA_COLLECTION="${INSTRUMENT}/defaults"  # Hardcoded into ap_verify, do not change!

--- a/scripts/make_empty_repo.sh
+++ b/scripts/make_empty_repo.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Script for generating a fresh Gen 3 repository in preloaded/. The previous
+# contents of the preloaded/ path are removed.
+
+
+# Abort script on any error
+set -e
+
+
+########################################
+# Repository creation
+
+REPO_DIR="${AP_VERIFY_CI_DC2_DIR:?'dataset is not set up'}/preloaded/"
+
+rm -rf "$REPO_DIR"
+butler create "$REPO_DIR"
+butler register-instrument "$REPO_DIR" lsst.obs.lsst.LsstCamImSim
+echo "Created empty LSSTCam-ImSim repo in ${REPO_DIR}."
+
+
+########################################
+# Minimal contents
+
+STD_CALIB="LSSTCam-imSim/calib"
+CURATED_CALIB="${STD_CALIB}/curated"
+# TODO: do we actually need this in the final collection chain?
+# UNBOUNDED_CALIB="${STD_CALIB}/unbounded"
+
+butler write-curated-calibrations "$REPO_DIR" lsst.obs.lsst.LsstCamImSim \
+    --collection "$CURATED_CALIB"
+butler collection-chain "$REPO_DIR" "$STD_CALIB" "$CURATED_CALIB"
+echo "Added curated calibrations to ${REPO_DIR}."

--- a/scripts/make_empty_repo.sh
+++ b/scripts/make_empty_repo.sh
@@ -28,7 +28,8 @@
 set -e
 
 
-REPO_DIR="${AP_VERIFY_DATASET_TEMPALTE_DIR:?'dataset is not set up'}/preloaded/"
+SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
+REPO_DIR="${SCRIPT_DIR}/../preloaded/"
 INST_CLASS=lsst.obs.lsst.LsstCam
 INST_NAME=LSSTCam
 

--- a/scripts/make_empty_repo.sh
+++ b/scripts/make_empty_repo.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file is part of ap_verify_ci_hits2015.
+# This file is part of ap_verify_dataset_template.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project
@@ -28,26 +28,27 @@
 set -e
 
 
+REPO_DIR="${AP_VERIFY_DATASET_TEMPALTE_DIR:?'dataset is not set up'}/preloaded/"
+INST_CLASS=lsst.obs.lsst.LsstCam
+INST_NAME=LSSTCam
+
+
 ########################################
 # Repository creation
 
-REPO_DIR="${AP_VERIFY_CI_DC2_DIR:?'dataset is not set up'}/preloaded/"
-
 rm -rf "$REPO_DIR"
 butler create "$REPO_DIR"
-butler register-instrument "$REPO_DIR" lsst.obs.lsst.LsstCamImSim
-echo "Created empty LSSTCam-ImSim repo in ${REPO_DIR}."
+butler register-instrument "$REPO_DIR" $INST_CLASS
+echo "Created empty $INST_NAME repo in ${REPO_DIR}."
 
 
 ########################################
 # Minimal contents
 
-STD_CALIB="LSSTCam-imSim/calib"
+STD_CALIB="${INST_NAME}/calib"
 CURATED_CALIB="${STD_CALIB}/curated"
-# TODO: do we actually need this in the final collection chain?
-# UNBOUNDED_CALIB="${STD_CALIB}/unbounded"
 
-butler write-curated-calibrations "$REPO_DIR" lsst.obs.lsst.LsstCamImSim \
+butler write-curated-calibrations "$REPO_DIR" $INST_CLASS \
     --collection "$CURATED_CALIB"
 butler collection-chain "$REPO_DIR" "$STD_CALIB" "$CURATED_CALIB"
 echo "Added curated calibrations to ${REPO_DIR}."

--- a/scripts/make_preloaded_export.py
+++ b/scripts/make_preloaded_export.py
@@ -1,9 +1,31 @@
 #!/usr/bin/env python
-"""
-Make the butler export yaml file to be used by ap_verify runs.
+# This file is part of ap_verify_dataset_template.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Make the butler export yaml file to be used by ap_verify runs.
+
+This script must be run after **any** change to the preloaded repository;
+otherwise, ingestion may fail or the changes may not be visible.
 """
 
-import argparse
 import logging
 import os
 import sys
@@ -11,14 +33,12 @@ import sys
 import lsst.log
 import lsst.skymap
 import lsst.daf.butler as daf_butler
-import lsst.ap.verify as ap_verify
 
 
-def _make_parser():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--dataset", required=True,
-                        help="The name of the dataset as recognized by ap_verify.py.")
-    return parser
+# Avoid explicit references to dataset package to maximize portability.
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "preloaded"))
+CONFIG_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "config"))
 
 
 def main():
@@ -26,26 +46,22 @@ def main():
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
     lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
 
-    args = _make_parser().parse_args()
-    dataset = ap_verify.dataset.Dataset(args.dataset)
-    gen3_repo = os.path.join(dataset.datasetRoot, "preloaded")
-
     logging.info("Exporting registry to configure new repos...")
-    _export_for_copy(dataset, gen3_repo)
+    _export_for_copy(REPO_DIR, CONFIG_DIR)
 
 
-def _export_for_copy(dataset, repo):
+def _export_for_copy(repo, export_dir):
     """Export a butler repository so that a dataset can make copies later.
 
     Parameters
     ----------
-    dataset : `lsst.ap.verify.dataset.Dataset`
-        The dataset needing the ability to copy the repository.
     repo : `str`
         The location of the repository.
+    export_dir : `str`
+        The location at which to create the export file.
     """
     butler = daf_butler.Butler(repo)
-    with butler.export(directory=dataset.configLocation, format="yaml") as contents:
+    with butler.export(directory=export_dir, format="yaml") as contents:
         # Need all detectors, even those without data, for visit definition
         contents.saveDataIds(butler.registry.queryDataIds({"detector"}).expanded())
         contents.saveDatasets(butler.registry.queryDatasets(datasetType=..., collections=...))

--- a/scripts/make_preloaded_export.py
+++ b/scripts/make_preloaded_export.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""
+Make the butler export yaml file to be used by ap_verify runs.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+import lsst.log
+import lsst.skymap
+import lsst.daf.butler as daf_butler
+import lsst.ap.verify as ap_verify
+
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", required=True,
+                        help="The name of the dataset as recognized by ap_verify.py.")
+    return parser
+
+
+def main():
+    # Ensure logs from tasks are visible
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+    args = _make_parser().parse_args()
+    dataset = ap_verify.dataset.Dataset(args.dataset)
+    gen3_repo = os.path.join(dataset.datasetRoot, "preloaded")
+
+    logging.info("Exporting registry to configure new repos...")
+    _export_for_copy(dataset, gen3_repo)
+
+
+def _export_for_copy(dataset, repo):
+    """Export a butler repository so that a dataset can make copies later.
+
+    Parameters
+    ----------
+    dataset : `lsst.ap.verify.dataset.Dataset`
+        The dataset needing the ability to copy the repository.
+    repo : `str`
+        The location of the repository.
+    """
+    butler = daf_butler.Butler(repo)
+    with butler.export(directory=dataset.configLocation, format="yaml") as contents:
+        # Need all detectors, even those without data, for visit definition
+        contents.saveDataIds(butler.registry.queryDataIds({"detector"}).expanded())
+        contents.saveDatasets(butler.registry.queryDatasets(datasetType=..., collections=...))
+        # Explicitly save the calibration and chained collections.
+        # Do _not_ include the RUN collections here because that will export
+        # an empty raws collection, which ap_verify assumes does not exist
+        # before ingest.
+        target_types = {daf_butler.CollectionType.CALIBRATION, daf_butler.CollectionType.CHAINED}
+        for collection in butler.registry.queryCollections(..., collectionTypes=target_types):
+            contents.saveCollection(collection)
+        # Export skymap collection even if it is empty
+        contents.saveCollection(lsst.skymap.BaseSkyMap.SKYMAP_RUN_COLLECTION_NAME)
+        # Dataset export exports visits, but need matching visit definitions as
+        # well (DefineVisitsTask won't add them back in).
+        contents.saveDimensionData("exposure",
+                                   butler.registry.queryDimensionRecords("exposure"))
+        contents.saveDimensionData("visit_definition",
+                                   butler.registry.queryDimensionRecords("visit_definition"))
+        contents.saveDimensionData("visit_detector_region",
+                                   butler.registry.queryDimensionRecords("visit_detector_region"))
+
+
+if __name__ == "__main__":
+    main()

--- a/ups/ap_verify_dataset_template.table
+++ b/ups/ap_verify_dataset_template.table
@@ -1,3 +1,8 @@
+# Data dependencies for this dataset.
+# This package should depend on the appropriate obs package and any other
+# packages needed to read the data. It should not depend on ap_verify or other
+# "pipelines-like" packages, as this may lead to circular dependencies.
+
 setupRequired(obs_lsst)
 # If the repository contains templates, include the PSF package used to make them.
 # This ensures they can be loaded even if the dependency isn't picked up elsewhere.

--- a/ups/ap_verify_dataset_template.table
+++ b/ups/ap_verify_dataset_template.table
@@ -1,1 +1,6 @@
-setupRequired(obs_test)
+setupRequired(obs_lsst)
+# If the repository contains templates, include the PSF package used to make them.
+# This ensures they can be loaded even if the dependency isn't picked up elsewhere.
+# Most coadd pipeliness use one of the following:
+# setupRequired(meas_extensions_psfex)
+# setupRequired(meas_extensions_piff)


### PR DESCRIPTION
This PR adds example dataset (re)generation scripts to the `scripts` directory, based on the existing scripts in [ap_verify_ci_hits2015/](https://github.com/lsst/ap_verify_ci_hits2015/) and [ap_verify_ci_dc2/](https://github.com/lsst/ap_verify_ci_dc2/). These scripts are not intended to be used directly, but instead to be copied to a new dataset on repository creation, and customized as needed there. I've tried to add enough documentation that a future developer would know what to change, but any feedback on how clear it is would be much appreciated.

The scripts were designed on the assumption that most future datasets will be small-scale. In particular, some scripts explicitly enumerate the raw data IDs to be used, and it's assumed that we won't be creating our own calibs like we did for HiTS.