### PR TITLE
DM-37667: Fix get_ephemerides.py

### DIFF
--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -2,8 +2,6 @@ description: Stub Alert Production pipeline
 #
 # NOTES
 # Remember to run make_apdb.py and use the same configs for diaPipe
-# READ_UNCOMMITTED is required for sqlite APDBs, i.e.,
-# -c diaPipe:apdb.isolation_level: 'READ_UNCOMMITTED'
 # A db_url is always required, e.g.,
 # -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
 # Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,


### PR DESCRIPTION
This PR backports a number of fixes made to `generate_ephemerides_gen3.py` on lsst/ap_verify_ci_cosmos_pdr2#32 to `get_ephemerides.py`. This makes up for the fact that the template version of the script has never been field-tested.