### PR TITLE
DM-38853: Change ap_verify CI packages to use Butler.transfer_from

### DIFF
--- a/scripts/ingest_refcats.py
+++ b/scripts/ingest_refcats.py
@@ -37,7 +37,6 @@ from lsst.daf.butler import Butler, CollectionType, FileDataset
 
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
-lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
 
 
 ########################################


### PR DESCRIPTION
This PR rewrites the refcat maintenance script to use Butler.transfer_from instead of Butler.ingest for copying the latest refcats from /repo/main. `transfer_from` is less flexible than `ingest`, so this change required removing the hardcoded run that was previously used to store all refcats.

This PR must be merged after https://github.com/lsst/daf_butler/pull/831.