### PR TITLE
DM-40629: Add GitHub PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+{Summary of changes. Prefix PR title with JIRA issue.}
+
+****
+
+- [ ] Did you run `ap_verify.py` on this dataset?
+- [ ] Are the Sphinx documentation and readme up-to-date?


### PR DESCRIPTION
This PR adds a PR template (to be copied into new dataset repos) reminding developers to run `ap_verify.py` for testing. Unfortunately, this PR is not a self-demonstrating example.