### PR TITLE
DM-42217: Incorporate ModelPackage Butler datasets into ap_verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ collection              | description
 `refcats`               | Level 7 HTM shards from relevant reference catalogs.
 `skymaps`               | Skymaps for the template coadds.
 `templates/<type>`      | Coadd images produced by a compatible version of the LSST pipelines. For example, `deepCoadd` images go in a `templates/deep` collection.
+`models`                | Pretrained machine learning models.
 `<instrument>/defaults` | A chained collection linking all of the above.
 
 Git LFS

--- a/config/rbClassify.py
+++ b/config/rbClassify.py
@@ -1,0 +1,6 @@
+# Config override for lsst.meas.transiNet.RBTransiNetTask
+# Ensure we're using the model that's actually in this dataset,
+# regardless of what task defaults are.
+
+config.modelPackageStorageMode = "butler"
+config.modelPackageName = None

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -9,3 +9,9 @@ description: Stub Alert Production pipeline
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipe.yaml
+tasks:
+  rbClassify:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      # Use dataset's model
+      file: $AP_VERIFY_DATASET_TEMPLATE_DIR/config/rbClassify.py

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -6,3 +6,10 @@ description: Stub instrumented Alert Production pipeline
 
 imports:
   - location: $AP_VERIFY_DIR/pipelines/LSSTCam-imSim/ApVerify.yaml
+tasks:
+  # Use the model that's actually in this dataset, regardless of defaults.
+  rbClassify:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      # Use dataset's model
+      file: $AP_VERIFY_DATASET_TEMPLATE_DIR/config/rbClassify.py

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -7,3 +7,10 @@ description: Stub instrumented Alert Production pipeline
 
 imports:
   - location: $AP_VERIFY_DIR/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
+tasks:
+  # Use the model that's actually in this dataset, regardless of defaults.
+  rbClassifyWithFakes:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      # Use dataset's model
+      file: $AP_VERIFY_DATASET_TEMPLATE_DIR/config/rbClassify.py

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,6 +17,7 @@ generate_templates.sh    | Create templates in an external repo (such as `repo/m
 make_empty_repo.sh       | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
 import_templates.py      | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
 import_calibs.py         | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`. Calibs are assumed to be generated as part of the regular reprocessing of the source repo, and there's no script for making them from scratch.
-ingest_refcats.py        | Transfer refcats from an external repo (such a `repo/main`) and register them in `preloaded/`.
+ingest_refcats.py        | Transfer refcats from an external repo (such as `repo/main`) and register them in `preloaded/`.
 get_ephemerides.py       | Download solar system ephemerides and register them in `preloaded/`.
+get_nn_models.py         | Transfer a selected pretrained model from an external repo (such as `repo/main`) and register it in `preloaded/`.
 make_preloaded_export.py | Create an export file of `preloaded/` that's compatible with `butler import`.

--- a/scripts/get_nn_models.py
+++ b/scripts/get_nn_models.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# This file is part of ap_verify_dataset_template.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Script for ingesting pretrained neural net models for this dataset.
+
+Running this script allows for updates or replacements of the existing model.
+
+Example:
+$ python get_nn_models.py -m rbResnet50-DC2
+imports rbResnet50-DC2 from /repo/main to this dataset's preloaded repo. See
+get_nn_models.py -h for more options.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+import lsst.log
+import lsst.skymap
+from lsst.daf.butler import Butler, CollectionType
+from lsst.meas.transiNet.modelPackages.storageAdapterButler import StorageAdapterButler
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+
+MODEL_PREFIX = StorageAdapterButler.packages_parent_collection
+MODEL_CHAIN = "models"  # Interface to make_all.sh
+
+# Avoid explicit references to dataset package to maximize portability.
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+DATASET_REPO = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "preloaded"))
+
+
+########################################
+# Command-line options
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", dest="src_dir", default="/repo/main",
+                        help="Repo to import from, defaults to '/repo/main'.")
+    parser.add_argument("-m", dest="model_name", required=True,
+                        help="Model package to import.")
+    return parser
+
+
+args = _make_parser().parse_args()
+
+
+########################################
+# Clean up existing model
+
+def _clean_dataset(butler):
+    """Remove the previous model(s), to avoid clashes on load.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler pointing to the repository to be cleaned.
+    """
+    try:
+        model_runs = butler.registry.getCollectionChain(MODEL_CHAIN)
+    except lsst.daf.butler.registry.MissingCollectionError:
+        # No prior collections
+        return
+
+    butler.registry.setCollectionChain(MODEL_CHAIN, [])
+    butler.removeRuns(model_runs, unstore=True)
+
+
+dest = Butler(DATASET_REPO, writeable=True)
+_clean_dataset(dest)
+
+
+########################################
+# Transfer
+
+MODEL_COLLECT = f"{MODEL_PREFIX}/{args.model_name}"
+
+src = Butler(args.src_dir, writeable=False)
+dest.transfer_from(src, src.registry.queryDatasets(..., collections=MODEL_COLLECT),
+                   transfer="copy", register_dataset_types=True)
+
+dest.registry.registerCollection(MODEL_CHAIN, CollectionType.CHAINED)
+dest.registry.setCollectionChain(MODEL_CHAIN, [MODEL_COLLECT])
+
+logging.info(f"Model {args.model_name} stored in {DATASET_REPO}:{MODEL_CHAIN}.")

--- a/scripts/ingest_refcats.py
+++ b/scripts/ingest_refcats.py
@@ -31,9 +31,7 @@ import logging
 import os
 import sys
 
-import lsst.log
-import lsst.sphgeom
-from lsst.daf.butler import Butler, CollectionType, FileDataset
+from lsst.daf.butler import Butler, CollectionType
 
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)

--- a/scripts/make_all.sh
+++ b/scripts/make_all.sh
@@ -41,6 +41,7 @@ DATASET_REPO="${SCRIPT_DIR}/../preloaded/"
 
 INSTRUMENT=LSSTCam
 UMBRELLA_COLLECTION="${INSTRUMENT}/defaults"  # Hardcoded into ap_verify, do not change!
+RB_MODEL="rbResnet50-DC2"
 
 ########################################
 # Command-line options
@@ -113,6 +114,12 @@ python "${SCRIPT_DIR}/ingest_refcats.py" -b ${SCRATCH_REPO} -i "${REFCAT_COLLECT
 
 
 ########################################
+# Import pretrained NN models
+
+python "${SCRIPT_DIR}/get_nn_models.py" -m "${RB_MODEL}"
+
+
+########################################
 # Download solar system ephemerides
 
 python "${SCRIPT_DIR}/generate_ephemerides.py"
@@ -122,7 +129,8 @@ python "${SCRIPT_DIR}/generate_ephemerides.py"
 # Final clean-up
 
 # The individual collections are set in the appropriate sub-scripts.
-butler collection-chain "${DATASET_REPO}" "${UMBRELLA_COLLECTION}" templates/goodSeeing skymaps ${INSTRUMENT}/calib refcats sso
+butler collection-chain "${DATASET_REPO}" "${UMBRELLA_COLLECTION}" \
+    templates/goodSeeing skymaps ${INSTRUMENT}/calib refcats sso models
 
 python "${SCRIPT_DIR}/make_preloaded_export.py"
 


### PR DESCRIPTION
This PR adds a script for ingesting model package Butler datasets into a new dataset, along with a pipeline config that should guarantee the model's use. Aside from the environment variable in the pipelines, these new elements can be used by new `ap_verify` data sets "as-is".

****

- [X] Are the Sphinx documentation and readme up-to-date?
