### PR TITLE
DM-42419: Break up ApVerify into pure with- and without-fakes pipelines

### DIFF
--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -9,7 +9,7 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
 tasks:
   # Use the model that's actually in this dataset, regardless of defaults.
-  rbClassifyWithFakes:
+  rbClassify:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
       # Use dataset's model


### PR DESCRIPTION
This PR updates the example pipelines to assume an `rbClassify` task rather than `rbClassifyWithFakes` (see lsst/ap_pipe#163).