### PR TITLE
DM-46341: Add readmes for script/ directory of ap_verify data sets

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,3 @@
-Copyright 2021-2022 University of Washington
+Copyright 2021-2025 University of Washington
+Copyright 2024 The Trustees of Princeton University
+Copyright 2024 CNRS/IN2P3

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Relevant Files and Directories
 ------------------------------
 path                  | description
 :---------------------|:-----------------------------
-`doc`                 | Contains Sphinx package documentation for the dataset. This documentation may be linked to from other packages, such as `ap_verify`.
-`raw`                 | To be populated with raw data. Data files do not need to follow a specific subdirectory structure. Currently contains a single small fits file (taken from `obs_test`) to test `git-lfs` functionality.
 `config`              | To be populated with dataset-specific configs. Currently empty.
+`doc`                 | Contains Sphinx package documentation for the dataset. This documentation may be linked to from other packages, such as `ap_verify`.
 `pipelines`           | To be populated with dataset-specific pipelines. Currently contains three example files specialized for ImSim data.
 `preloaded`           | To be populated with a Gen 3 Butler repository (see below). This repository must never be written to; instead, it should be copied to a separate location before use (this is handled automatically by `ap_verify`, see below).
+`raw`                 | To be populated with raw data. Data files do not need to follow a specific subdirectory structure. Currently contains a single small fits file (taken from `obs_test`) to test `git-lfs` functionality.
 `scripts`             | Contains example scripts for populating `raw` and/or `preloaded`. Scripts may need to be specialized for a particular dataset before use.
 `dataIds.list`        | List of dataIds in this repo. For use in running Tasks. Currently set to run all Ids.
 
@@ -29,12 +29,12 @@ The Gen 3 repository in `preloaded/` must contain the following collections; the
 
 collection              | description
 :-----------------------|:-----------------------------
+`<instrument>/defaults` | A chained collection linking all of the below.
 `<instrument>/calib`    | Master calibration files for the data in the `raw` directory.
+`models`                | Pretrained machine learning models.
 `refcats`               | Level 7 HTM shards from relevant reference catalogs.
 `skymaps`               | Skymaps for the template coadds.
 `templates/<type>`      | Coadd images produced by a compatible version of the LSST pipelines. For example, `deepCoadd` images go in a `templates/deep` collection.
-`models`                | Pretrained machine learning models.
-`<instrument>/defaults` | A chained collection linking all of the above.
 
 Git LFS
 -------

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,9 @@ This directory has example scripts for (re)creating an ap_verify dataset.
 Adopting such scripts for your own datasets is highly recommended, to make it easy to update the pipeline inputs (in particular, calibs and templates) for pipeline improvements.
 These scripts are *not* intended to be used as-is; they may require some fine-tuning to adapt to the specifics of your data set.
 
+*Any* change to the repo requires running `make_preloaded_export.py` to ensure the export file is up-to-date.
+The data set will not run correctly without this step, but it also makes it easy to see and review each commit's changes.
+
 The scripts are designed to be modular, and can be called either all at once (through `make_all.sh`), or individually.
 See each script's docstring for usage instructions; those scripts that take arguments also support `--help`.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,16 +10,16 @@ See each script's docstring for usage instructions; those scripts that take argu
 
 Contents
 --------
-path                         | description
-:----------------------------|:-----------------------------
-make_all.sh                  | Rebuild everything from scratch.
-generate_group_dimensions.py | Predefine the group dimensions corresponding to the input raws. This allows support for preprocessing datasets.
-generate_self_preload.py     | Create preloaded APDB datasets by simulating a processing run with no pre-existing DIAObjects.
-generate_templates.sh        | Create templates in an external repo (such as `repo/main`) that cover this dataset's area.
-get_ephemerides.py           | Download solar system ephemerides and register them in `preloaded/`.
-get_nn_models.py             | Transfer a selected pretrained model from an external repo (such as `repo/main`) and register it in `preloaded/`.
-import_calibs.py             | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`. Calibs are assumed to be generated as part of the regular reprocessing of the source repo, and there's no script for making them from scratch.
-import_templates.py          | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
-ingest_refcats.py            | Transfer refcats from an external repo (such as `repo/main`) and register them in `preloaded/`.
-make_empty_repo.sh           | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
-make_preloaded_export.py     | Create an export file of `preloaded/` that's compatible with `butler import`.
+path                               | description
+:----------------------------------|:-----------------------------
+make_all.sh                        | Rebuild everything from scratch.
+generate_fake_injection_catalog.sh | Create source injection catalogs in a specific box on the sky. Requires templates.
+generate_group_dimensions.py       | Predefine the group dimensions corresponding to the input raws. This allows support for preprocessing datasets.
+generate_self_preload.py           | Create preloaded APDB datasets by simulating a processing run with no pre-existing DIAObjects.
+get_ephemerides.py                 | Download solar system ephemerides and register them in `preloaded/`.
+get_nn_models.py                   | Transfer a selected pretrained model from an external repo (such as `repo/main`) and register it in `preloaded/`.
+import_calibs.py                   | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`.
+import_templates.py                | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
+ingest_refcats.py                  | Transfer refcats from an external repo (such as `repo/main`) and register them in `preloaded/`.
+make_empty_repo.sh                 | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
+make_preloaded_export.py           | Create an export file of `preloaded/` that's compatible with `butler import`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,10 +16,10 @@ make_all.sh                  | Rebuild everything from scratch.
 generate_group_dimensions.py | Predefine the group dimensions corresponding to the input raws. This allows support for preprocessing datasets.
 generate_self_preload.py     | Create preloaded APDB datasets by simulating a processing run with no pre-existing DIAObjects.
 generate_templates.sh        | Create templates in an external repo (such as `repo/main`) that cover this dataset's area.
-make_empty_repo.sh           | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
-import_templates.py          | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
-import_calibs.py             | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`. Calibs are assumed to be generated as part of the regular reprocessing of the source repo, and there's no script for making them from scratch.
-ingest_refcats.py            | Transfer refcats from an external repo (such as `repo/main`) and register them in `preloaded/`.
 get_ephemerides.py           | Download solar system ephemerides and register them in `preloaded/`.
 get_nn_models.py             | Transfer a selected pretrained model from an external repo (such as `repo/main`) and register it in `preloaded/`.
+import_calibs.py             | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`. Calibs are assumed to be generated as part of the regular reprocessing of the source repo, and there's no script for making them from scratch.
+import_templates.py          | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
+ingest_refcats.py            | Transfer refcats from an external repo (such as `repo/main`) and register them in `preloaded/`.
+make_empty_repo.sh           | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
 make_preloaded_export.py     | Create an export file of `preloaded/` that's compatible with `butler import`.

--- a/scripts/generate_fake_injection_catalog.sh
+++ b/scripts/generate_fake_injection_catalog.sh
@@ -32,6 +32,17 @@ set -e
 
 
 ########################################
+# Per data set configuration
+
+TEMPLATE_TYPE=goodSeeing  # Must match the type used in this data set
+BANDS="g"                 # Band(s) for which to generate fakes
+RA_RANGE="152.0 156.0"    # Catalog box in degrees
+DEC_RANGE="-6.02 -5.6"
+MAG_RANGE="18 26"
+DENSITY=5000              # Source density in deg^-2
+
+
+########################################
 # Capture repository and script directory
 
 SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
@@ -72,20 +83,22 @@ parse_args() {
 }
 parse_args $@
 
+TEMPLATE_NAME=${TEMPLATE_TYPE}Coadd
+TEMPLATE_COLLECT=templates/${TEMPLATE_TYPE}
 
 # The -a (RA) and -d (Dec) options are the limits of the sky polygon
 #  where to draw random fake positions, -s is source density per sq degree,
-#  -m is the magnitude interval, -i is the filter set to use, and --seed fixes the random see to use. 
+#  -m is the magnitude interval, -i is the filter set to use, and --seed fixes the random see to use.
 generate_injection_catalog \
-    -a 152.0 156.0 \
-    -d -6.02 -5.6 \
+    # Expansions of *_RANGE and BANDS are unquoted so that they expand into multiple words
+    -a $RA_RANGE \
+    -d $DEC_RANGE \
     -p source_type Star \
-    -s 5000 \
-    -b ${BUTLER_REPO} \
-    -w goodSeeingCoadd \
-    -c 'templates/goodSeeing' \
-    -o ${OUTPUT_COLLECTION} \
-    -m 18 26 \
-    -i g \
-    --seed 314 
-
+    -s ${DENSITY} \
+    -b "${BUTLER_REPO}" \
+    -w "$TEMPLATE_NAME" \
+    -c "$TEMPLATE_COLLECT" \
+    -o "${OUTPUT_COLLECTION}" \
+    -m $MAG_RANGE \
+    -i $BANDS \
+    --seed 314

--- a/scripts/generate_fake_injection_catalog.sh
+++ b/scripts/generate_fake_injection_catalog.sh
@@ -21,7 +21,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Script for automatically generating fake source injection catalogs.
-# This automatically ingests the catalogs into the preloaded butler.
+# This script requires the source_injection repository to be set up, and for
+# templates to already exist in this data set.
 #
 # Example:
 # "${SCRIPT_DIR}/generate_fake_injection_catalog.sh" -b ${DATASET_REPO} -o ${INJECTION_CATALOG_COLLECTION}

--- a/scripts/generate_fake_injection_catalog.sh
+++ b/scripts/generate_fake_injection_catalog.sh
@@ -54,7 +54,7 @@ print_error() {
 
 usage() {
     print_error
-    print_error "Usage: $0 [-b BUTLER_REPO] -c ROOT_COLLECTION [-h]"
+    print_error "Usage: $0 [-b BUTLER_REPO] -o OUTPUT_COLLECTION [-h]"
     print_error
     print_error "Specific options:"
     print_error "   -b          Butler repo yaml file URI, defaults to preloaded repo"


### PR DESCRIPTION
This PR does a variety of cleanups and updates to the template's documentation. It also refactors `generate_fake_injection_catalog.sh` to make it easier to customize (and more obvious that it *must* be customized).

****

- [ ] Did you run `ap_verify.py` on this data set?
- [ ] If you made changes to `scripts/`, should those changes be propagated to [ap_verify_dataset_template](https://github.com/lsst-dm/ap_verify_dataset_template/), or are they specific to this data set?
- [X] Are the Sphinx documentation and readme up-to-date?
